### PR TITLE
Alpha5 revisions

### DIFF
--- a/packages/lazarus-shared/browser/index.js
+++ b/packages/lazarus-shared/browser/index.js
@@ -4,6 +4,7 @@ import GAM from '@base-cms/marko-web-gam/browser';
 import RevealAd from '@base-cms/marko-web-reveal-ad/browser';
 
 import IncrementAdPos from './increment-ad-pos.vue';
+import LoadEloquaIframes from './load-eloqua-iframes.vue';
 
 export default (Browser) => {
   DefaultTheme(Browser);
@@ -15,4 +16,5 @@ export default (Browser) => {
   Browser.register('LazarusSharedIncrementAdPos', IncrementAdPos, {
     provide: { EventBus },
   });
+  Browser.register('LazarusSharedLoadEloquaIframes', LoadEloquaIframes);
 };

--- a/packages/lazarus-shared/browser/load-eloqua-iframes.vue
+++ b/packages/lazarus-shared/browser/load-eloqua-iframes.vue
@@ -17,8 +17,6 @@ export default {
       const src = element.getAttribute('data-src');
       const hasProcessed = element.getAttribute('data-has-processed');
       if (!hasProcessed && src) {
-        // element.classList.add('lazyload');
-        // element.
         const iframe = document.createElement('iframe');
         iframe.setAttribute('data-src', src);
         iframe.setAttribute('class', 'lazyload eloqua-iframe');

--- a/packages/lazarus-shared/browser/load-eloqua-iframes.vue
+++ b/packages/lazarus-shared/browser/load-eloqua-iframes.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="lazarus-load-eloqua-iframes" :data-selector="selector" style="display: none;" />
+</template>
+
+<script>
+export default {
+  props: {
+    selector: {
+      type: String,
+      default: '.penton-eloqua-form',
+    },
+  },
+
+  created() {
+    const elements = document.querySelectorAll(this.selector);
+    Array.prototype.forEach.call(elements, (element) => {
+      const src = element.getAttribute('data-src');
+      const hasProcessed = element.getAttribute('data-has-processed');
+      if (!hasProcessed && src) {
+        // element.classList.add('lazyload');
+        // element.
+        const iframe = document.createElement('iframe');
+        iframe.setAttribute('data-src', src);
+        iframe.setAttribute('class', 'lazyload eloqua-iframe');
+        element.setAttribute('data-has-processed', 'true');
+        element.appendChild(iframe);
+      }
+    });
+  },
+};
+</script>

--- a/packages/lazarus-shared/components/blocks/global-left-rail.marko
+++ b/packages/lazarus-shared/components/blocks/global-left-rail.marko
@@ -4,6 +4,7 @@ import queryFragment from "../../graphql/fragments/content-list";
 
 $ const adunit = getAsObject(input, "adunit");
 $ const slotId = generateId();
+$ const includeContentTypes = ["Article", "MediaGallery", "Video"];
 
 <if(adunit.location && adunit.position)>
   <lazarus-shared-increment-ad-pos slot-id=slotId />
@@ -11,7 +12,13 @@ $ const slotId = generateId();
 </if>
 
 <!-- @todo check out stickybits js lib for handling position: sticky -->
-<marko-web-query|{ nodes }| name="all-published-content" params={ limit: 2, excludeContentTypes: ["Contact"], queryFragment }>
+<marko-web-query|{ nodes }|
+  name="all-published-content"
+  params={
+    limit: 2,
+    includeContentTypes,
+    queryFragment,
+  }>
   <lazarus-shared-content-list-flow
     nodes=nodes
     inner-justified=false
@@ -35,7 +42,14 @@ $ const slotId = generateId();
   />
 </if>
 
-<marko-web-query|{ nodes }| name="all-published-content" params={ limit: 3, skip: 2, excludeContentTypes: ["Contact"], queryFragment }>
+<marko-web-query|{ nodes }|
+  name="all-published-content"
+  params={
+    limit: 3,
+    skip: 2,
+    includeContentTypes,
+    queryFragment,
+  }>
   <lazarus-shared-content-list-flow
     nodes=nodes
     inner-justified=false
@@ -49,8 +63,12 @@ $ const slotId = generateId();
 
 <marko-web-query|{ nodes }|
   name="website-optioned-content"
-  params={ sectionAlias: "home", optionName: "Pinned", limit: 4, queryFragment }
->
+  params={
+    sectionAlias: "home",
+    optionName: "Pinned",
+    limit: 4,
+    queryFragment,
+  }>
   <lazarus-shared-content-list-flow
     nodes=nodes
     inner-justified=false

--- a/packages/lazarus-shared/components/load-eloqua-iframes.marko
+++ b/packages/lazarus-shared/components/load-eloqua-iframes.marko
@@ -1,0 +1,4 @@
+$ const { bodyId } = input;
+$ const selector = `#${bodyId} .penton-eloqua-form`;
+
+<marko-web-browser-component name="LazarusSharedLoadEloquaIframes" props={ selector } />

--- a/packages/lazarus-shared/components/marko.json
+++ b/packages/lazarus-shared/components/marko.json
@@ -8,6 +8,10 @@
     "template": "./increment-ad-pos.marko",
     "@slot-id": "string"
   },
+  "<lazrus-load-eloqua-iframes>": {
+    "template": "./load-eloqua-iframes",
+    "@body-id": "string"
+  },
   "<lazarus-shared-document>": {
     "template": "./document.marko",
     "<head>": {},

--- a/packages/lazarus-shared/components/marko.json
+++ b/packages/lazarus-shared/components/marko.json
@@ -8,7 +8,7 @@
     "template": "./increment-ad-pos.marko",
     "@slot-id": "string"
   },
-  "<lazrus-load-eloqua-iframes>": {
+  "<lazarus-load-eloqua-iframes>": {
     "template": "./load-eloqua-iframes",
     "@body-id": "string"
   },

--- a/packages/lazarus-shared/components/nodes/content-card.marko
+++ b/packages/lazarus-shared/components/nodes/content-card.marko
@@ -1,13 +1,15 @@
-import { getAsObject } from "@base-cms/object-path";
+import { getAsObject, getAsArray } from "@base-cms/object-path";
 import defaultValue from "@base-cms/marko-core/utils/default-value";
 
 $ const content = getAsObject(input, "node");
 $ const primaryImage = getAsObject(content, "primaryImage");
 $ const primarySection = getAsObject(content, "primarySection");
+$ const isSponsored = getAsArray(content, "labels").includes("Sponsored");
 
 $ const withTeaser = defaultValue(input.withTeaser, true);
 $ const withSection = defaultValue(input.withSection, true);
 $ const withDates = defaultValue(input.withDates, true);
+$ const withSponsored = defaultValue(input.withSponsored, true);
 
 $ const { linkAttrs } = input;
 
@@ -34,6 +36,13 @@ $ const { linkAttrs } = input;
     />
   </if>
   <@body>
+    <if(withSponsored && isSponsored)>
+      <@header>
+        <@left|{ blockName }|>
+          <div class=`${blockName}__sponsored-content`>Sponsored Content</div>
+        </@left>
+      </@header>
+    </if>
     <@title tag="h5" ...input.title>
       <marko-web-content-short-name tag=null obj=content link={ attrs: linkAttrs } />
     </@title>

--- a/packages/lazarus-shared/components/nodes/content-list.marko
+++ b/packages/lazarus-shared/components/nodes/content-list.marko
@@ -1,13 +1,15 @@
-import { getAsObject } from "@base-cms/object-path";
+import { getAsObject, getAsArray } from "@base-cms/object-path";
 import defaultValue from "@base-cms/marko-core/utils/default-value";
 
 $ const content = getAsObject(input, "node");
 $ const primaryImage = getAsObject(content, "primaryImage");
 $ const primarySection = getAsObject(content, "primarySection");
+$ const isSponsored = getAsArray(content, "labels").includes("Sponsored");
 
 $ const withTeaser = defaultValue(input.withTeaser, true);
 $ const withSection = defaultValue(input.withSection, true);
 $ const withDates = defaultValue(input.withDates, true);
+$ const withSponsored = defaultValue(input.withSponsored, true);
 
 $ const { linkAttrs } = input;
 
@@ -33,6 +35,13 @@ $ const { linkAttrs } = input;
     />
   </if>
   <@body>
+    <if(withSponsored && isSponsored)>
+      <@header>
+        <@left|{ blockName }|>
+          <div class=`${blockName}__sponsored-content`>Sponsored Content</div>
+        </@left>
+      </@header>
+    </if>
     <@title tag="h5"  ...input.title>
       <marko-web-content-short-name tag=null obj=content link={ attrs: linkAttrs } />
     </@title>

--- a/packages/lazarus-shared/components/nodes/content-page-card.marko
+++ b/packages/lazarus-shared/components/nodes/content-page-card.marko
@@ -1,0 +1,80 @@
+import { getAsObject, getAsArray } from "@base-cms/object-path";
+import { buildImgixUrl } from "@base-cms/image";
+
+$ const blockName = "content-page-card";
+
+$ const content = getAsObject(input, "content");
+$ const primaryImage = getAsObject(content, "primaryImage");
+$ const primarySection = getAsObject(content, "primarySection");
+$ const isSponsored = getAsArray(content, "labels").includes("Sponsored");
+
+$ const { type } = content;
+
+$ const hasImage = Boolean(primaryImage.src);
+$ const src = buildImgixUrl(primaryImage.src, { w: 768, h: 432 });
+$ const srcset = [`${buildImgixUrl(src, { dpr: 2 })} 2x`];
+
+$ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? false : true;
+
+<!-- @todo determine where to place video embeds -->
+<!-- @todo add lower-right image caption -->
+<marko-web-block
+  name=blockName
+  tag=input.tag
+  class=input.class
+  modifiers=input.modifiers
+  attrs=input.attrs
+>
+  <marko-web-node-element name="header" block-name=blockName>
+    <if(hasImage)>
+      <marko-web-node-element name="header-image-wrapper" block-name=blockName>
+        <marko-web-node-element name="image-inner-wrapper" block-name=blockName>
+          <marko-web-img
+            src=src
+            srcset=srcset
+            alt=primaryImage.alt
+            class=`${blockName}__image`
+            lazyload=true
+          />
+          <marko-web-image-credit block-name=blockName obj=primaryImage />
+        </marko-web-node-element>
+      </marko-web-node-element>
+    </if>
+    <marko-web-node-element name="header-body" block-name=blockName>
+      <if(isSponsored)>
+        <div class=`${blockName}__sponsored-content`>Sponsored Content</div>
+      </if>
+      <default-theme-website-section-breadcrumbs
+        section=primarySection
+        display-home=false
+        modifiers=[blockName]
+      />
+      <marko-web-content-name
+        tag="h1"
+        block-name=blockName
+        obj=content
+      />
+      <marko-web-content-teaser
+        tag="p"
+        block-name=blockName
+        obj=content
+      />
+
+      <if(type !== "contact")>
+        <default-theme-content-attribution obj=content />
+        <default-theme-page-dates|{ blockName }|>
+          <if(type === "event")>
+            <marko-web-content-start-date block-name=blockName obj=content />
+            <marko-web-content-end-date block-name=blockName obj=content />
+          </if>
+          <if(type === "webinar")>
+            <marko-web-content-start-date block-name=blockName obj=content />
+          </if>
+          <if(displayPublishedDate)>
+            <marko-web-content-published block-name=blockName obj=content />
+          </if>
+        </default-theme-page-dates>
+      </if>
+    </marko-web-node-element>
+  </marko-web-node-element>
+</marko-web-block>

--- a/packages/lazarus-shared/components/nodes/content-page.marko
+++ b/packages/lazarus-shared/components/nodes/content-page.marko
@@ -7,7 +7,7 @@ $ const { type } = content;
 $ const primarySection = getAsObject(content, "primarySection");
 
 <lazarus-skin-page-grid-col modifiers=["content-page"]>
-  <lazarus-skin-content-page-card content=content />
+  <lazarus-shared-content-page-card content=content />
 
   <default-theme-page-contents|{ blockName }|>
     <default-theme-content-contact-details obj=content />

--- a/packages/lazarus-shared/components/nodes/content-page.marko
+++ b/packages/lazarus-shared/components/nodes/content-page.marko
@@ -21,6 +21,9 @@ $ const primarySection = getAsObject(content, "primarySection");
 
     $ const bodyId = `content-body-${content.id}`;
     <marko-web-content-body block-name=blockName obj=content attrs={ id: bodyId } />
+    <!-- Load "embedded" Eloqua iframes -->
+    <lazarus-load-eloqua-iframes body-id=bodyId />
+
     <!-- @todo inject teads and native ad blocks -->
     <informa-gam-inject-adunits selector=`#${bodyId}`>
       <@inject

--- a/packages/lazarus-shared/components/nodes/marko.json
+++ b/packages/lazarus-shared/components/nodes/marko.json
@@ -27,6 +27,7 @@
     "@with-teaser": "boolean",
     "@with-section": "boolean",
     "@with-dates": "boolean",
+    "@with-sponsored": "boolean",
 
     "@modifiers": "array",
     "@attrs": "object",

--- a/packages/lazarus-shared/components/nodes/marko.json
+++ b/packages/lazarus-shared/components/nodes/marko.json
@@ -40,5 +40,13 @@
   "<lazarus-shared-contact-us-list-node>": {
     "template": "./contact-us-list.marko",
     "@node": "object"
+  },
+  "<lazarus-shared-content-page-card>": {
+    "template": "./content-page-card.marko",
+    "@content": "object",
+    "@tag": "string",
+    "@class": "string",
+    "@modifiers": "array",
+    "@attrs": "object"
   }
 }

--- a/packages/lazarus-shared/components/nodes/marko.json
+++ b/packages/lazarus-shared/components/nodes/marko.json
@@ -10,6 +10,7 @@
     "@with-teaser": "boolean",
     "@with-section": "boolean",
     "@with-dates": "boolean",
+    "@with-sponsored": "boolean",
 
     "@modifiers": "array",
     "@attrs": "object",

--- a/packages/lazarus-shared/graphql/fragments/content-list.js
+++ b/packages/lazarus-shared/graphql/fragments/content-list.js
@@ -10,6 +10,7 @@ fragment WebsiteContentListFragment on Content {
   siteContext {
     path
   }
+  labels
   published
   primarySection {
     id

--- a/packages/lazarus-shared/graphql/fragments/content-page.js
+++ b/packages/lazarus-shared/graphql/fragments/content-page.js
@@ -7,6 +7,7 @@ fragment ContentPageFragment on Content {
   teaser(input: { useFallback: false, maxLength: null })
   body
   published
+  labels
   company {
     id
     name

--- a/packages/lazarus-shared/package.json
+++ b/packages/lazarus-shared/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@base-cms/env": "^1.0.0-rc.1",
+    "@base-cms/image": "^1.0.0-rc.1",
     "@base-cms/marko-core": "^1.0.0-rc.8",
     "@base-cms/marko-web": "^1.0.0-rc.10",
     "@base-cms/marko-web-gam": "^1.0.0-rc.10",

--- a/packages/lazarus-shared/start-server.js
+++ b/packages/lazarus-shared/start-server.js
@@ -1,6 +1,6 @@
 const newrelic = require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
-const { get } = require('@base-cms/object-path');
+const { get, set } = require('@base-cms/object-path');
 const gam = require('@endeavor-business-media/informa-gam/middleware');
 const cleanResponse = require('@base-cms/marko-core/middleware/clean-marko-response');
 
@@ -19,7 +19,14 @@ module.exports = (options = {}) => {
     onStart: async (app) => {
       if (typeof onStart === 'function') await onStart(app);
       app.set('trust proxy', 'loopback, linklocal, uniquelocal');
+      // Setup GAM middleware (if configure).
       if (gamConfig) app.use(gam(gamConfig));
+      // Force set all date formats.
+      app.use((req, res, next) => {
+        set(app.locals, 'markoCoreDate.format', 'MMM D, YYYY');
+        next();
+      });
+      // Clean all response bodies.
       app.use(cleanResponse());
     },
     onAsyncBlockError: e => newrelic.noticeError(e),

--- a/packages/lazarus-shared/templates/content/index.marko
+++ b/packages/lazarus-shared/templates/content/index.marko
@@ -2,6 +2,7 @@ import adLocation from "@endeavor-business-media/lazarus-shared/utils/gam/conten
 
 $ const { site } = out.global;
 $ const { id, type, pageNode } = data;
+$ const infiniteScrollEnabled = type === 'webinar' ? false : true;
 
 <marko-web-content-page-layout id=id type=type>
   <@head>
@@ -35,15 +36,17 @@ $ const { id, type, pageNode } = data;
             <@right-col>
               <@bottom-row>
                 <lazarus-shared-content-page-node node=content />
-                <marko-web-load-more
-                  append-to=".page-grid__bottom-row"
-                  expand=500
-                  component-name="lazarus-shared-content-page-load-more-flow"
-                  fragment-name="content-page"
-                  query-name="website-scheduled-content"
-                  query-params={ sectionId: section.id, limit: 1, skip: 0, excludeContentIds: [id] }
-                  page-input={ for: "content", id, type }
-                />
+                <if(infiniteScrollEnabled)>
+                  <marko-web-load-more
+                    append-to=".page-grid__bottom-row"
+                    expand=500
+                    component-name="lazarus-shared-content-page-load-more-flow"
+                    fragment-name="content-page"
+                    query-name="website-scheduled-content"
+                    query-params={ sectionId: section.id, limit: 1, skip: 0, excludeContentIds: [id] }
+                    page-input={ for: "content", id, type }
+                  />
+                </if>
               </@bottom-row>
             </@right-col>
           </lazarus-skin-page-grid>

--- a/packages/lazarus-shared/theme.scss
+++ b/packages/lazarus-shared/theme.scss
@@ -32,6 +32,8 @@ $theme-site-header-breakpoints: (
 @import "../../node_modules/@base-cms/marko-web-reveal-ad/scss/reveal-ad";
 @import "../../node_modules/@base-cms/marko-web-theme-default/skins/lazarus/skin.scss";
 
+$theme-sponsored-content-color: #ee591d !default;
+
 @mixin gutter-padding-x() {
   padding-right: $grid-gutter-width / 2;
   padding-left: $grid-gutter-width / 2;
@@ -57,6 +59,16 @@ $theme-site-header-breakpoints: (
 .node {
   &__title {
     @include theme-line-height-crop($theme-item-title-line-height);
+  }
+
+  &__sponsored-content {
+    $line-height: 1.35;
+    @include theme-line-height-crop($line-height);
+    font-size: 12px;
+    font-weight: 700;
+    line-height: $line-height;
+    color: $theme-sponsored-content-color;
+    text-transform: uppercase;
   }
 }
 

--- a/packages/lazarus-shared/theme.scss
+++ b/packages/lazarus-shared/theme.scss
@@ -63,6 +63,10 @@ $theme-site-header-breakpoints: (
 .node-list {
   @include gutter-padding-x-modifier();
   @include gutter-padding-y-modifier();
+
+  &--related-content {
+    padding-top: map-get($spacers, block);
+  }
 }
 
 .page-grid {
@@ -109,6 +113,10 @@ $theme-site-header-breakpoints: (
   width: 100%;
   height: 100%;
   border: 0;
+}
+
+.embed-container-eloqua {
+  padding-bottom: $theme-content-paragraph-margin-bottom;
 }
 
 .page-contents {

--- a/packages/lazarus-shared/theme.scss
+++ b/packages/lazarus-shared/theme.scss
@@ -57,6 +57,7 @@ $theme-sponsored-content-color: #ee591d !default;
 }
 
 .node {
+  $self: &;
   &__title {
     @include theme-line-height-crop($theme-item-title-line-height);
   }
@@ -69,6 +70,14 @@ $theme-sponsored-content-color: #ee591d !default;
     line-height: $line-height;
     color: $theme-sponsored-content-color;
     text-transform: uppercase;
+  }
+
+  &--card {
+    #{ $self } {
+      &__sponsored-content {
+        margin-top: .25rem;
+      }
+    }
   }
 }
 

--- a/packages/lazarus-shared/theme.scss
+++ b/packages/lazarus-shared/theme.scss
@@ -103,3 +103,18 @@ $theme-site-header-breakpoints: (
     @include gutter-padding-y();
   }
 }
+
+// Informa/Penton Eloqua Forms
+.eloqua-iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.page-contents {
+  &__content-body {
+    p + .embed-container-eloqua {
+      margin-top: -$theme-content-paragraph-margin-bottom;
+    }
+  }
+}

--- a/packages/lazarus-shared/theme.scss
+++ b/packages/lazarus-shared/theme.scss
@@ -34,6 +34,16 @@ $theme-site-header-breakpoints: (
 
 $theme-sponsored-content-color: #ee591d !default;
 
+@mixin sponsored-content-tag() {
+  $line-height: 1.35;
+  @include theme-line-height-crop($line-height);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: $line-height;
+  color: $theme-sponsored-content-color;
+  text-transform: uppercase;
+}
+
 @mixin gutter-padding-x() {
   padding-right: $grid-gutter-width / 2;
   padding-left: $grid-gutter-width / 2;
@@ -63,13 +73,7 @@ $theme-sponsored-content-color: #ee591d !default;
   }
 
   &__sponsored-content {
-    $line-height: 1.35;
-    @include theme-line-height-crop($line-height);
-    font-size: 12px;
-    font-weight: 700;
-    line-height: $line-height;
-    color: $theme-sponsored-content-color;
-    text-transform: uppercase;
+    @include sponsored-content-tag();
   }
 
   &--card {
@@ -78,6 +82,13 @@ $theme-sponsored-content-color: #ee591d !default;
         margin-top: .25rem;
       }
     }
+  }
+}
+
+.content-page-card {
+  &__sponsored-content {
+    @include sponsored-content-tag();
+    margin-bottom: .75rem;
   }
 }
 

--- a/sites/tdworld.com/config/navigation.js
+++ b/sites/tdworld.com/config/navigation.js
@@ -40,8 +40,8 @@ module.exports = {
     {
       modifiers: ['secondary'],
       items: [
-        { href: '/webinars', label: 'Webinars' },
-        { href: '/white-papers', label: 'White Papers' },
+        { href: '/resources/webinars', label: 'Webinars' },
+        { href: '/resources/white-papers', label: 'White Papers' },
         { href: 'https://informa.dragonforms.com/PEN6138_TWland&PK=NN71RA', label: 'Magazine Subscription', target: '_blank' },
         { href: 'https://eb.informabi.com/LP=1056', label: 'eNewlsetter Subscription', target: '_blank' },
         { href: '/contact-us', label: 'Contact Us' },


### PR DESCRIPTION
- Remove "TH" from date formats (force for all sites)
- Handle Eloqua iframes in content bodies
- Disable infinite scroll on webinar pages
- Only show Article, MediaGallery and Video in global, left-rail feed
- Fix T&D World webinar and whitepaper links in menu
- Add "Sponsored Content" label to content lists, cards, and content page