### PR TITLE
Account for root level GAM targeting and breakpoints; add testAd param

### DIFF
--- a/packages/informa-gam/components/adunit.marko
+++ b/packages/informa-gam/components/adunit.marko
@@ -3,7 +3,8 @@ import { warn } from "@base-cms/utils";
 import adunitAttrs from "../utils/create-adunit-attrs";
 import incrementPos from "../utils/increment-pos";
 
-$ const { gam } = out.global;
+$ const { gam, req } = out.global;
+$ const { testAd } = req.query;
 $ const {
   location,
   position,
@@ -16,7 +17,7 @@ $ const {
     $ const adunits = resolved.get(position);
     <if(adunits)>
       <for|adunit| of=adunits>
-        $ const targeting = { ...adunit.targeting, ...input.targeting };
+        $ const targeting = { ...adunit.targeting, ...input.targeting, ...(testAd && { testAd }) };
         $ const attrs = adunitAttrs({ location, position, context, adunit });
         $ const { pos } = targeting;
         $ if (posIncrement && pos) targeting.pos = incrementPos({ pos, inc: posIncrement });

--- a/packages/informa-gam/components/inject-adunits.marko
+++ b/packages/informa-gam/components/inject-adunits.marko
@@ -2,7 +2,8 @@ import { getAsArray } from "@base-cms/object-path";
 import { warn } from "@base-cms/utils";
 import adunitAttrs from "../utils/create-adunit-attrs";
 
-$ const { gam } = out.global;
+$ const { gam, req } = out.global;
+$ const { testAd } = req.query;
 
 $ const inject = getAsArray(input, "inject").filter(o => o && o.at);
 $ const promises = Promise.all(inject.map(async (unitInput) => {
@@ -23,7 +24,7 @@ $ const promises = Promise.all(inject.map(async (unitInput) => {
     path: adunit.path,
     size: adunit.size,
     sizeMapping: adunit.sizeMapping,
-    targeting: ({ ...adunit.targeting, ...unitInput.targeting }),
+    targeting: ({ ...adunit.targeting, ...unitInput.targeting, ...(testAd && { testAd }) }),
     id: unitInput.id,
     modifiers: unitInput.modifiers,
     applyStyle: unitInput.apply,

--- a/packages/informa-gam/package.json
+++ b/packages/informa-gam/package.json
@@ -14,7 +14,7 @@
     "@base-cms/inflector": "^1.0.0-rc.1",
     "@base-cms/marko-core": "^1.0.0-rc.8",
     "@base-cms/marko-web": "^1.0.0-rc.10",
-    "@base-cms/marko-web-gam": "^1.0.0-rc.13",
+    "@base-cms/marko-web-gam": "^1.0.0-rc.14",
     "@base-cms/object-path": "^1.0.0-rc.1",
     "@base-cms/utils": "^1.0.0-rc.1",
     "@base-cms/web-cli": "^1.0.0-rc.10",

--- a/packages/lazarus-shared/package.json
+++ b/packages/lazarus-shared/package.json
@@ -14,7 +14,7 @@
     "@base-cms/image": "^1.0.0-rc.1",
     "@base-cms/marko-core": "^1.0.0-rc.8",
     "@base-cms/marko-web": "^1.0.0-rc.10",
-    "@base-cms/marko-web-gam": "^1.0.0-rc.13",
+    "@base-cms/marko-web-gam": "^1.0.0-rc.14",
     "@base-cms/marko-web-gtm": "^1.0.0-rc.1",
     "@base-cms/marko-web-icons": "^1.0.0-rc.1",
     "@base-cms/marko-web-reveal-ad": "^1.0.0-rc.1",

--- a/services/gam/graphql/utils/adunit-projection.js
+++ b/services/gam/graphql/utils/adunit-projection.js
@@ -9,4 +9,7 @@ module.exports = {
   'settings.position': 1,
   'settings.targeting': 1,
   'settings.breakpoints': 1,
+  // Some adunits have this data at the root.
+  targeting: 1,
+  breakpoints: 1,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -789,10 +789,10 @@
     moment "^2.24.0"
     moment-timezone "^0.5.26"
 
-"@base-cms/marko-web-gam@^1.0.0-rc.13":
-  version "1.0.0-rc.13"
-  resolved "https://registry.yarnpkg.com/@base-cms/marko-web-gam/-/marko-web-gam-1.0.0-rc.13.tgz#b9e38ba70b995ac4866035bc3ea5dadc6c6a3c58"
-  integrity sha512-rknOLau7mWm/blR88wLiK3fbiLWM4iyCJPZhqcxIH2qP2PlzI79SJ9P5hSO8rsGrVPMP0BPbu9VoR8X5kdjteg==
+"@base-cms/marko-web-gam@^1.0.0-rc.14":
+  version "1.0.0-rc.14"
+  resolved "https://registry.yarnpkg.com/@base-cms/marko-web-gam/-/marko-web-gam-1.0.0-rc.14.tgz#a17602c5ae56b1c56d25eae6c3ef0aca23f9050d"
+  integrity sha512-+DjlPWgVwQ2eewVY5WpL7IFQJ8uYL+8jOJz+tvaT1/MmB6JQT6gxmIBFns62J8hMiwAnmZB7l9PbDYQltqNubQ==
   dependencies:
     "@base-cms/object-path" "^1.0.0-rc.1"
     "@base-cms/utils" "^1.0.0-rc.1"


### PR DESCRIPTION
Some GAM configs have their targeting and breakpoint settings defined at the root of the object instead of under `settings`. The GAM service resolvers now account for this.

- Fixes issue where some ads were showing on larger screen sizes when they shouldn't have
- Handles the `testAd` query parameter and passes the value along to GAM as a targeting key/value
- Upgrades `@base-cms/marko-web-gam` to `1.0.0-rc.14` which now displays the `sizeMapping` property as a data attribute