### PR TITLE
Ensure dynamic page routes support “deep” paths

### DIFF
--- a/sites/americanmachinist.com/server/routes/dynamic-page.js
+++ b/sites/americanmachinist.com/server/routes/dynamic-page.js
@@ -3,7 +3,7 @@ const page = require('@endeavor-business-media/lazarus-shared/templates/dynamic-
 const queryFragment = require('@endeavor-business-media/lazarus-shared/graphql/fragments/dynamic-page');
 
 module.exports = (app) => {
-  app.get('/page/:alias', withDynamicPage({
+  app.get('/page/:alias([a-z0-9-/]+)', withDynamicPage({
     template: page,
     queryFragment,
   }));

--- a/sites/asumag.com/server/routes/dynamic-page.js
+++ b/sites/asumag.com/server/routes/dynamic-page.js
@@ -3,7 +3,7 @@ const page = require('@endeavor-business-media/lazarus-shared/templates/dynamic-
 const queryFragment = require('@endeavor-business-media/lazarus-shared/graphql/fragments/dynamic-page');
 
 module.exports = (app) => {
-  app.get('/page/:alias', withDynamicPage({
+  app.get('/page/:alias([a-z0-9-/]+)', withDynamicPage({
     template: page,
     queryFragment,
   }));

--- a/sites/bulktransporter.com/server/routes/dynamic-page.js
+++ b/sites/bulktransporter.com/server/routes/dynamic-page.js
@@ -3,7 +3,7 @@ const page = require('@endeavor-business-media/lazarus-shared/templates/dynamic-
 const queryFragment = require('@endeavor-business-media/lazarus-shared/graphql/fragments/dynamic-page');
 
 module.exports = (app) => {
-  app.get('/page/:alias', withDynamicPage({
+  app.get('/page/:alias([a-z0-9-/]+)', withDynamicPage({
     template: page,
     queryFragment,
   }));

--- a/sites/contractingbusiness.com/server/routes/dynamic-page.js
+++ b/sites/contractingbusiness.com/server/routes/dynamic-page.js
@@ -3,7 +3,7 @@ const page = require('@endeavor-business-media/lazarus-shared/templates/dynamic-
 const queryFragment = require('@endeavor-business-media/lazarus-shared/graphql/fragments/dynamic-page');
 
 module.exports = (app) => {
-  app.get('/page/:alias', withDynamicPage({
+  app.get('/page/:alias([a-z0-9-/]+)', withDynamicPage({
     template: page,
     queryFragment,
   }));

--- a/sites/contractormag.com/server/routes/dynamic-page.js
+++ b/sites/contractormag.com/server/routes/dynamic-page.js
@@ -3,7 +3,7 @@ const page = require('@endeavor-business-media/lazarus-shared/templates/dynamic-
 const queryFragment = require('@endeavor-business-media/lazarus-shared/graphql/fragments/dynamic-page');
 
 module.exports = (app) => {
-  app.get('/page/:alias', withDynamicPage({
+  app.get('/page/:alias([a-z0-9-/]+)', withDynamicPage({
     template: page,
     queryFragment,
   }));

--- a/sites/ecmweb.com/server/routes/dynamic-page.js
+++ b/sites/ecmweb.com/server/routes/dynamic-page.js
@@ -3,7 +3,7 @@ const page = require('@endeavor-business-media/lazarus-shared/templates/dynamic-
 const queryFragment = require('@endeavor-business-media/lazarus-shared/graphql/fragments/dynamic-page');
 
 module.exports = (app) => {
-  app.get('/page/:alias', withDynamicPage({
+  app.get('/page/:alias([a-z0-9-/]+)', withDynamicPage({
     template: page,
     queryFragment,
   }));

--- a/sites/ehstoday.com/server/routes/dynamic-page.js
+++ b/sites/ehstoday.com/server/routes/dynamic-page.js
@@ -3,7 +3,7 @@ const page = require('@endeavor-business-media/lazarus-shared/templates/dynamic-
 const queryFragment = require('@endeavor-business-media/lazarus-shared/graphql/fragments/dynamic-page');
 
 module.exports = (app) => {
-  app.get('/page/:alias', withDynamicPage({
+  app.get('/page/:alias([a-z0-9-/]+)', withDynamicPage({
     template: page,
     queryFragment,
   }));

--- a/sites/electricalmarketing.com/server/routes/dynamic-page.js
+++ b/sites/electricalmarketing.com/server/routes/dynamic-page.js
@@ -3,7 +3,7 @@ const page = require('@endeavor-business-media/lazarus-shared/templates/dynamic-
 const queryFragment = require('@endeavor-business-media/lazarus-shared/graphql/fragments/dynamic-page');
 
 module.exports = (app) => {
-  app.get('/page/:alias', withDynamicPage({
+  app.get('/page/:alias([a-z0-9-/]+)', withDynamicPage({
     template: page,
     queryFragment,
   }));

--- a/sites/electronicdesign.com/server/routes/dynamic-page.js
+++ b/sites/electronicdesign.com/server/routes/dynamic-page.js
@@ -3,7 +3,7 @@ const page = require('@endeavor-business-media/lazarus-shared/templates/dynamic-
 const queryFragment = require('@endeavor-business-media/lazarus-shared/graphql/fragments/dynamic-page');
 
 module.exports = (app) => {
-  app.get('/page/:alias', withDynamicPage({
+  app.get('/page/:alias([a-z0-9-/]+)', withDynamicPage({
     template: page,
     queryFragment,
   }));

--- a/sites/ewweb.com/server/routes/dynamic-page.js
+++ b/sites/ewweb.com/server/routes/dynamic-page.js
@@ -3,7 +3,7 @@ const page = require('@endeavor-business-media/lazarus-shared/templates/dynamic-
 const queryFragment = require('@endeavor-business-media/lazarus-shared/graphql/fragments/dynamic-page');
 
 module.exports = (app) => {
-  app.get('/page/:alias', withDynamicPage({
+  app.get('/page/:alias([a-z0-9-/]+)', withDynamicPage({
     template: page,
     queryFragment,
   }));

--- a/sites/fleetowner.com/server/routes/dynamic-page.js
+++ b/sites/fleetowner.com/server/routes/dynamic-page.js
@@ -3,7 +3,7 @@ const page = require('@endeavor-business-media/lazarus-shared/templates/dynamic-
 const queryFragment = require('@endeavor-business-media/lazarus-shared/graphql/fragments/dynamic-page');
 
 module.exports = (app) => {
-  app.get('/page/:alias', withDynamicPage({
+  app.get('/page/:alias([a-z0-9-/]+)', withDynamicPage({
     template: page,
     queryFragment,
   }));

--- a/sites/forgingmagazine.com/server/routes/dynamic-page.js
+++ b/sites/forgingmagazine.com/server/routes/dynamic-page.js
@@ -3,7 +3,7 @@ const page = require('@endeavor-business-media/lazarus-shared/templates/dynamic-
 const queryFragment = require('@endeavor-business-media/lazarus-shared/graphql/fragments/dynamic-page');
 
 module.exports = (app) => {
-  app.get('/page/:alias', withDynamicPage({
+  app.get('/page/:alias([a-z0-9-/]+)', withDynamicPage({
     template: page,
     queryFragment,
   }));

--- a/sites/foundrymag.com/server/routes/dynamic-page.js
+++ b/sites/foundrymag.com/server/routes/dynamic-page.js
@@ -3,7 +3,7 @@ const page = require('@endeavor-business-media/lazarus-shared/templates/dynamic-
 const queryFragment = require('@endeavor-business-media/lazarus-shared/graphql/fragments/dynamic-page');
 
 module.exports = (app) => {
-  app.get('/page/:alias', withDynamicPage({
+  app.get('/page/:alias([a-z0-9-/]+)', withDynamicPage({
     template: page,
     queryFragment,
   }));

--- a/sites/hpac.com/server/routes/dynamic-page.js
+++ b/sites/hpac.com/server/routes/dynamic-page.js
@@ -3,7 +3,7 @@ const page = require('@endeavor-business-media/lazarus-shared/templates/dynamic-
 const queryFragment = require('@endeavor-business-media/lazarus-shared/graphql/fragments/dynamic-page');
 
 module.exports = (app) => {
-  app.get('/page/:alias', withDynamicPage({
+  app.get('/page/:alias([a-z0-9-/]+)', withDynamicPage({
     template: page,
     queryFragment,
   }));

--- a/sites/hydraulicspneumatics.com/server/routes/dynamic-page.js
+++ b/sites/hydraulicspneumatics.com/server/routes/dynamic-page.js
@@ -3,7 +3,7 @@ const page = require('@endeavor-business-media/lazarus-shared/templates/dynamic-
 const queryFragment = require('@endeavor-business-media/lazarus-shared/graphql/fragments/dynamic-page');
 
 module.exports = (app) => {
-  app.get('/page/:alias', withDynamicPage({
+  app.get('/page/:alias([a-z0-9-/]+)', withDynamicPage({
     template: page,
     queryFragment,
   }));

--- a/sites/industryweek.com/server/routes/dynamic-page.js
+++ b/sites/industryweek.com/server/routes/dynamic-page.js
@@ -3,7 +3,7 @@ const page = require('@endeavor-business-media/lazarus-shared/templates/dynamic-
 const queryFragment = require('@endeavor-business-media/lazarus-shared/graphql/fragments/dynamic-page');
 
 module.exports = (app) => {
-  app.get('/page/:alias', withDynamicPage({
+  app.get('/page/:alias([a-z0-9-/]+)', withDynamicPage({
     template: page,
     queryFragment,
   }));

--- a/sites/machinedesign.com/server/routes/dynamic-page.js
+++ b/sites/machinedesign.com/server/routes/dynamic-page.js
@@ -3,7 +3,7 @@ const page = require('@endeavor-business-media/lazarus-shared/templates/dynamic-
 const queryFragment = require('@endeavor-business-media/lazarus-shared/graphql/fragments/dynamic-page');
 
 module.exports = (app) => {
-  app.get('/page/:alias', withDynamicPage({
+  app.get('/page/:alias([a-z0-9-/]+)', withDynamicPage({
     template: page,
     queryFragment,
   }));

--- a/sites/mhlnews.com/server/routes/dynamic-page.js
+++ b/sites/mhlnews.com/server/routes/dynamic-page.js
@@ -3,7 +3,7 @@ const page = require('@endeavor-business-media/lazarus-shared/templates/dynamic-
 const queryFragment = require('@endeavor-business-media/lazarus-shared/graphql/fragments/dynamic-page');
 
 module.exports = (app) => {
-  app.get('/page/:alias', withDynamicPage({
+  app.get('/page/:alias([a-z0-9-/]+)', withDynamicPage({
     template: page,
     queryFragment,
   }));

--- a/sites/mwrf.com/server/routes/dynamic-page.js
+++ b/sites/mwrf.com/server/routes/dynamic-page.js
@@ -3,7 +3,7 @@ const page = require('@endeavor-business-media/lazarus-shared/templates/dynamic-
 const queryFragment = require('@endeavor-business-media/lazarus-shared/graphql/fragments/dynamic-page');
 
 module.exports = (app) => {
-  app.get('/page/:alias', withDynamicPage({
+  app.get('/page/:alias([a-z0-9-/]+)', withDynamicPage({
     template: page,
     queryFragment,
   }));

--- a/sites/newequipment.com/server/routes/dynamic-page.js
+++ b/sites/newequipment.com/server/routes/dynamic-page.js
@@ -3,7 +3,7 @@ const page = require('@endeavor-business-media/lazarus-shared/templates/dynamic-
 const queryFragment = require('@endeavor-business-media/lazarus-shared/graphql/fragments/dynamic-page');
 
 module.exports = (app) => {
-  app.get('/page/:alias', withDynamicPage({
+  app.get('/page/:alias([a-z0-9-/]+)', withDynamicPage({
     template: page,
     queryFragment,
   }));

--- a/sites/powerelectronics.com/server/routes/dynamic-page.js
+++ b/sites/powerelectronics.com/server/routes/dynamic-page.js
@@ -3,7 +3,7 @@ const page = require('@endeavor-business-media/lazarus-shared/templates/dynamic-
 const queryFragment = require('@endeavor-business-media/lazarus-shared/graphql/fragments/dynamic-page');
 
 module.exports = (app) => {
-  app.get('/page/:alias', withDynamicPage({
+  app.get('/page/:alias([a-z0-9-/]+)', withDynamicPage({
     template: page,
     queryFragment,
   }));

--- a/sites/refrigeratedtransporter.com/server/routes/dynamic-page.js
+++ b/sites/refrigeratedtransporter.com/server/routes/dynamic-page.js
@@ -3,7 +3,7 @@ const page = require('@endeavor-business-media/lazarus-shared/templates/dynamic-
 const queryFragment = require('@endeavor-business-media/lazarus-shared/graphql/fragments/dynamic-page');
 
 module.exports = (app) => {
-  app.get('/page/:alias', withDynamicPage({
+  app.get('/page/:alias([a-z0-9-/]+)', withDynamicPage({
     template: page,
     queryFragment,
   }));

--- a/sites/rermag.com/server/routes/dynamic-page.js
+++ b/sites/rermag.com/server/routes/dynamic-page.js
@@ -3,7 +3,7 @@ const page = require('@endeavor-business-media/lazarus-shared/templates/dynamic-
 const queryFragment = require('@endeavor-business-media/lazarus-shared/graphql/fragments/dynamic-page');
 
 module.exports = (app) => {
-  app.get('/page/:alias', withDynamicPage({
+  app.get('/page/:alias([a-z0-9-/]+)', withDynamicPage({
     template: page,
     queryFragment,
   }));

--- a/sites/sourcetoday.com/server/routes/dynamic-page.js
+++ b/sites/sourcetoday.com/server/routes/dynamic-page.js
@@ -3,7 +3,7 @@ const page = require('@endeavor-business-media/lazarus-shared/templates/dynamic-
 const queryFragment = require('@endeavor-business-media/lazarus-shared/graphql/fragments/dynamic-page');
 
 module.exports = (app) => {
-  app.get('/page/:alias', withDynamicPage({
+  app.get('/page/:alias([a-z0-9-/]+)', withDynamicPage({
     template: page,
     queryFragment,
   }));

--- a/sites/tdworld.com/server/routes/dynamic-page.js
+++ b/sites/tdworld.com/server/routes/dynamic-page.js
@@ -3,7 +3,7 @@ const page = require('@endeavor-business-media/lazarus-shared/templates/dynamic-
 const queryFragment = require('@endeavor-business-media/lazarus-shared/graphql/fragments/dynamic-page');
 
 module.exports = (app) => {
-  app.get('/page/:alias', withDynamicPage({
+  app.get('/page/:alias([a-z0-9-/]+)', withDynamicPage({
     template: page,
     queryFragment,
   }));

--- a/sites/trailer-bodybuilders.com/server/routes/dynamic-page.js
+++ b/sites/trailer-bodybuilders.com/server/routes/dynamic-page.js
@@ -3,7 +3,7 @@ const page = require('@endeavor-business-media/lazarus-shared/templates/dynamic-
 const queryFragment = require('@endeavor-business-media/lazarus-shared/graphql/fragments/dynamic-page');
 
 module.exports = (app) => {
-  app.get('/page/:alias', withDynamicPage({
+  app.get('/page/:alias([a-z0-9-/]+)', withDynamicPage({
     template: page,
     queryFragment,
   }));

--- a/sites/trucker.com/server/routes/dynamic-page.js
+++ b/sites/trucker.com/server/routes/dynamic-page.js
@@ -3,7 +3,7 @@ const page = require('@endeavor-business-media/lazarus-shared/templates/dynamic-
 const queryFragment = require('@endeavor-business-media/lazarus-shared/graphql/fragments/dynamic-page');
 
 module.exports = (app) => {
-  app.get('/page/:alias', withDynamicPage({
+  app.get('/page/:alias([a-z0-9-/]+)', withDynamicPage({
     template: page,
     queryFragment,
   }));

--- a/sites/truckfleetmro.com/server/routes/dynamic-page.js
+++ b/sites/truckfleetmro.com/server/routes/dynamic-page.js
@@ -3,7 +3,7 @@ const page = require('@endeavor-business-media/lazarus-shared/templates/dynamic-
 const queryFragment = require('@endeavor-business-media/lazarus-shared/graphql/fragments/dynamic-page');
 
 module.exports = (app) => {
-  app.get('/page/:alias', withDynamicPage({
+  app.get('/page/:alias([a-z0-9-/]+)', withDynamicPage({
     template: page,
     queryFragment,
   }));


### PR DESCRIPTION
Previously, `/page/foo/bar` would not not match the dynamic page route. This fixes that issue.