### PR TITLE
Create newsletter signup block and add Dragon Forms config

### DIFF
--- a/packages/lazarus-shared/components/blocks/marko.json
+++ b/packages/lazarus-shared/components/blocks/marko.json
@@ -12,5 +12,8 @@
       "@location": "string",
       "<context>": {}
     }
+  },
+  "<lazarus-shared-newsletter-signup-block>": {
+    "template": "./omeda-newsletter-signup.marko"
   }
 }

--- a/packages/lazarus-shared/components/blocks/omeda-newsletter-signup.marko
+++ b/packages/lazarus-shared/components/blocks/omeda-newsletter-signup.marko
@@ -1,0 +1,35 @@
+$ const blockName = "newsletter-signup-block";
+
+$ const { config, site } = out.global;
+$ const omedaSite = site.get("dragonForms.newsletterSignup");
+
+<if(omedaSite)>
+  <marko-web-block name=blockName>
+    <marko-web-element block-name=blockName name="title">
+      Sign up for ${config.website("name")} eNewsletters
+    </marko-web-element>
+
+    <marko-web-element
+      block-name=blockName
+      name="form"
+      tag="form"
+      attrs={ action: "https://endeavor.dragonforms.com/loading.do", method: "GET" }
+    >
+      <marko-web-element
+        block-name=blockName
+        name="field-wrapper"
+      >
+        <input type="hidden" name="omedasite" value=omedaSite>
+        <input type="email" placeholder="Email address" required="true" name="em" class=`${blockName}__email-field`>
+        <marko-web-element
+          tag="button"
+          block-name=blockName
+          name="submit-button"
+          attrs={ type: "submit" }
+        >
+          Sign Up
+        </marko-web-element>
+      </marko-web-element>
+    </marko-web-element>
+  </marko-web-block>
+</if>

--- a/packages/lazarus-shared/components/blocks/omeda-newsletter-signup.marko
+++ b/packages/lazarus-shared/components/blocks/omeda-newsletter-signup.marko
@@ -1,16 +1,13 @@
 import { get } from "@base-cms/object-path";
+import DragonFormsConfig from "../../config/dragon-forms";
 
 $ const blockName = "newsletter-signup-block";
 
 $ const { config, site } = out.global;
-$ const dragonForms = site.get("dragonForms");
+$ const dragonForms = site.get("dragonForms") || new DragonFormsConfig({ url: "https://placeholder.dragonforms.com" });
 
-$ let action;
-$ let omedasite;
-$ if (dragonForms) {
-  action = typeof dragonForms.getFormAction === "function" ? dragonForms.getFormAction() : null;
-  omedasite = typeof dragonForms.getOmedaSite === "function" ? dragonForms.getOmedaSite({ key: "newsletterSignup" }) : null;
-}
+$ const action = dragonForms.getFormAction();
+$ const { omedasite, options } = dragonForms.getForm("newsletterSignup");
 
 <if(action && omedasite)>
   <marko-web-block name=blockName>
@@ -29,6 +26,11 @@ $ if (dragonForms) {
         name="field-wrapper"
       >
         <input type="hidden" name="omedasite" value=omedasite>
+        <if(options)>
+          <for|name, value| in=options>
+            <input type="hidden" name=name value=value>
+          </for>
+        </if>
         <input type="email" placeholder="Email address" required="true" name="em" class=`${blockName}__email-field`>
         <marko-web-element
           tag="button"

--- a/packages/lazarus-shared/components/blocks/omeda-newsletter-signup.marko
+++ b/packages/lazarus-shared/components/blocks/omeda-newsletter-signup.marko
@@ -1,9 +1,10 @@
 $ const blockName = "newsletter-signup-block";
 
 $ const { config, site } = out.global;
-$ const omedaSite = site.get("dragonForms.newsletterSignup");
+$ const action = site.get("dragonForms.url");
+$ const form = site.get("dragonForms.forms.newsletterSignup")
 
-<if(omedaSite)>
+<if(form && action)>
   <marko-web-block name=blockName>
     <marko-web-element block-name=blockName name="title">
       Sign up for ${config.website("name")} eNewsletters
@@ -13,13 +14,13 @@ $ const omedaSite = site.get("dragonForms.newsletterSignup");
       block-name=blockName
       name="form"
       tag="form"
-      attrs={ action: "https://endeavor.dragonforms.com/loading.do", method: "GET" }
+      attrs={ action, method: "GET" }
     >
       <marko-web-element
         block-name=blockName
         name="field-wrapper"
       >
-        <input type="hidden" name="omedasite" value=omedaSite>
+        <input type="hidden" name="omedasite" value=form>
         <input type="email" placeholder="Email address" required="true" name="em" class=`${blockName}__email-field`>
         <marko-web-element
           tag="button"

--- a/packages/lazarus-shared/components/blocks/omeda-newsletter-signup.marko
+++ b/packages/lazarus-shared/components/blocks/omeda-newsletter-signup.marko
@@ -7,7 +7,7 @@ $ const { config, site } = out.global;
 $ const dragonForms = site.get("dragonForms") || new DragonFormsConfig({ url: "https://placeholder.dragonforms.com" });
 
 $ const action = dragonForms.getFormAction();
-$ const { omedasite, options } = dragonForms.getForm("newsletterSignup");
+$ const { omedasite, query } = dragonForms.getForm("newsletterSignup");
 
 <if(action && omedasite)>
   <marko-web-block name=blockName>
@@ -26,8 +26,8 @@ $ const { omedasite, options } = dragonForms.getForm("newsletterSignup");
         name="field-wrapper"
       >
         <input type="hidden" name="omedasite" value=omedasite>
-        <if(options)>
-          <for|name, value| in=options>
+        <if(query)>
+          <for|name, value| in=query>
             <input type="hidden" name=name value=value>
           </for>
         </if>

--- a/packages/lazarus-shared/components/blocks/omeda-newsletter-signup.marko
+++ b/packages/lazarus-shared/components/blocks/omeda-newsletter-signup.marko
@@ -1,10 +1,18 @@
+import { get } from "@base-cms/object-path";
+
 $ const blockName = "newsletter-signup-block";
 
 $ const { config, site } = out.global;
-$ const action = site.get("dragonForms.url");
-$ const form = site.get("dragonForms.forms.newsletterSignup")
+$ const dragonForms = site.get("dragonForms");
 
-<if(form && action)>
+$ let action;
+$ let omedasite;
+$ if (dragonForms) {
+  action = typeof dragonForms.getFormAction === "function" ? dragonForms.getFormAction() : null;
+  omedasite = typeof dragonForms.getOmedaSite === "function" ? dragonForms.getOmedaSite({ key: "newsletterSignup" }) : null;
+}
+
+<if(action && omedasite)>
   <marko-web-block name=blockName>
     <marko-web-element block-name=blockName name="title">
       Sign up for ${config.website("name")} eNewsletters
@@ -20,7 +28,7 @@ $ const form = site.get("dragonForms.forms.newsletterSignup")
         block-name=blockName
         name="field-wrapper"
       >
-        <input type="hidden" name="omedasite" value=form>
+        <input type="hidden" name="omedasite" value=omedasite>
         <input type="email" placeholder="Email address" required="true" name="em" class=`${blockName}__email-field`>
         <marko-web-element
           tag="button"

--- a/packages/lazarus-shared/components/flows/content-page-load-more.marko
+++ b/packages/lazarus-shared/components/flows/content-page-load-more.marko
@@ -2,6 +2,13 @@ import { getAsArray } from "@base-cms/object-path";
 import adLocation from "@endeavor-business-media/lazarus-shared/utils/gam/content-ad-location";
 
 $ const nodes = getAsArray(input, "nodes");
+$ const { pageNumber } = input;
+
+<if(pageNumber === 1)>
+  <lazarus-skin-page-grid-col modifiers=["full", "no-gutters"]>
+    <lazarus-shared-newsletter-signup-block />
+  </lazarus-skin-page-grid-col>
+</if>
 
 <if(nodes.length)>
   $ const content = nodes[0];
@@ -9,7 +16,7 @@ $ const nodes = getAsArray(input, "nodes");
     <informa-gam-adunit
       location=adLocation(content.type)
       position="infinitescroll"
-      pos-increment=(input.pageNumber - 1)
+      pos-increment=(pageNumber - 1)
       modifiers=["max-width-728", "margin-auto-x"]
     >
       <@context content-id=content.id />

--- a/packages/lazarus-shared/config/dragon-forms.js
+++ b/packages/lazarus-shared/config/dragon-forms.js
@@ -1,29 +1,34 @@
-const { URL } = require('url');
+const { URL, URLSearchParams } = require('url');
 
 class DragonFormsConfig {
   constructor({ url }) {
     if (!url) throw new Error('The DragonForms URL is required.');
     this.url = (new URL(url)).origin;
-    this.omedasites = {};
+    this.forms = {};
   }
 
-  addOmedaSite({ key, omedasite }) {
-    this.omedasites[key] = omedasite;
+  addForm(key, { omedasite, options } = {}) {
+    if (!omedasite) throw new Error('The `omedasite` value is required.');
+    this.forms[key] = { omedasite, options };
     return this;
   }
 
-  getFormUrl({ key }) {
-    const omedasite = this.getOmedaSite({ key });
+  getFormUrl(key) {
+    const { omedasite, options } = this.getForm(key);
     if (!omedasite) return null;
-    return `${this.getFormAction()}?omedasite=${omedasite}`;
+    const params = new URLSearchParams({
+      ...options,
+      omedasite,
+    });
+    return `${this.getFormAction()}?${params}`;
   }
 
   getFormAction() {
     return `${this.url}/loading.do`;
   }
 
-  getOmedaSite({ key }) {
-    return this.omedasites[key];
+  getForm(key) {
+    return this.forms[key] || {};
   }
 }
 

--- a/packages/lazarus-shared/config/dragon-forms.js
+++ b/packages/lazarus-shared/config/dragon-forms.js
@@ -7,17 +7,17 @@ class DragonFormsConfig {
     this.forms = {};
   }
 
-  addForm(key, { omedasite, options } = {}) {
+  addForm(key, { omedasite, query } = {}) {
     if (!omedasite) throw new Error('The `omedasite` value is required.');
-    this.forms[key] = { omedasite, options };
+    this.forms[key] = { omedasite, query };
     return this;
   }
 
   getFormUrl(key) {
-    const { omedasite, options } = this.getForm(key);
+    const { omedasite, query } = this.getForm(key);
     if (!omedasite) return null;
     const params = new URLSearchParams({
-      ...options,
+      ...query,
       omedasite,
     });
     return `${this.getFormAction()}?${params}`;

--- a/packages/lazarus-shared/config/dragon-forms.js
+++ b/packages/lazarus-shared/config/dragon-forms.js
@@ -1,0 +1,30 @@
+const { URL } = require('url');
+
+class DragonFormsConfig {
+  constructor({ url }) {
+    if (!url) throw new Error('The DragonForms URL is required.');
+    this.url = (new URL(url)).origin;
+    this.omedasites = {};
+  }
+
+  addOmedaSite({ key, omedasite }) {
+    this.omedasites[key] = omedasite;
+    return this;
+  }
+
+  getFormUrl({ key }) {
+    const omedasite = this.getOmedaSite({ key });
+    if (!omedasite) return null;
+    return `${this.getFormAction()}?omedasite=${omedasite}`;
+  }
+
+  getFormAction() {
+    return `${this.url}/loading.do`;
+  }
+
+  getOmedaSite({ key }) {
+    return this.omedasites[key];
+  }
+}
+
+module.exports = DragonFormsConfig;

--- a/packages/lazarus-shared/package.json
+++ b/packages/lazarus-shared/package.json
@@ -18,7 +18,7 @@
     "@base-cms/marko-web-gcse": "^1.0.1",
     "@base-cms/marko-web-gtm": "^1.0.3",
     "@base-cms/marko-web-icons": "^1.0.0",
-    "@base-cms/marko-web-theme-default": "^1.0.1",
+    "@base-cms/marko-web-theme-default": "^1.1.0",
     "@base-cms/object-path": "^1.0.0",
     "@base-cms/utils": "^1.0.0",
     "@base-cms/web-cli": "^1.0.2",

--- a/packages/lazarus-shared/templates/content/index.marko
+++ b/packages/lazarus-shared/templates/content/index.marko
@@ -37,10 +37,6 @@ $ const infiniteScrollEnabled = ["webinar", "whitepaper"].includes(type) ? false
               <@bottom-row>
                 <lazarus-shared-content-page-node node=content />
 
-                <div class="col-12 mt-block p-0">
-                  <lazarus-shared-newsletter-signup-block />
-                </div>
-
                 <if(infiniteScrollEnabled)>
                   <marko-web-load-more
                     append-to=".page-grid__bottom-row"

--- a/packages/lazarus-shared/templates/content/index.marko
+++ b/packages/lazarus-shared/templates/content/index.marko
@@ -36,6 +36,11 @@ $ const infiniteScrollEnabled = ["webinar", "whitepaper"].includes(type) ? false
             <@right-col>
               <@bottom-row>
                 <lazarus-shared-content-page-node node=content />
+
+                <div class="col-12 mt-block p-0">
+                  <lazarus-shared-newsletter-signup-block />
+                </div>
+
                 <if(infiniteScrollEnabled)>
                   <marko-web-load-more
                     append-to=".page-grid__bottom-row"

--- a/packages/lazarus-shared/templates/index.marko
+++ b/packages/lazarus-shared/templates/index.marko
@@ -28,7 +28,7 @@ $ const { id, alias, name, pageNode } = data;
             </@left-col>
             <@right-col>
               <@top-row>
-                <div class="col">
+                <div class="col-12">
                   <marko-web-query|{ nodes }|
                     name="website-optioned-content"
                     params={ sectionId: id, optionName: "Pinned", limit: 4, requiresImage: true, queryFragment }
@@ -70,6 +70,10 @@ $ const { id, alias, name, pageNode } = data;
                 </div>
               </@top-row>
               <@bottom-row>
+                <div class="col-12 mb-block p-0">
+                  <lazarus-shared-newsletter-signup-block />
+                </div>
+
                 $ const [sectionA, sectionB, sectionC] = site.getAsArray("homePageSections");
                 <if(sectionA)>
                   <div class="col-md-6 mb-block">

--- a/packages/lazarus-shared/templates/index.marko
+++ b/packages/lazarus-shared/templates/index.marko
@@ -70,9 +70,9 @@ $ const { id, alias, name, pageNode } = data;
                 </div>
               </@top-row>
               <@bottom-row>
-                <div class="col-12 mb-block p-0">
+                <lazarus-skin-page-grid-col modifiers=["full", "no-gutters", "bottom-spacer"]>
                   <lazarus-shared-newsletter-signup-block />
-                </div>
+                </lazarus-skin-page-grid-col>
 
                 $ const [sectionA, sectionB, sectionC] = site.getAsArray("homePageSections");
                 <if(sectionA)>

--- a/packages/lazarus-shared/templates/website-section/index.marko
+++ b/packages/lazarus-shared/templates/website-section/index.marko
@@ -86,9 +86,9 @@ $ const { id, alias, name, pageNode } = data;
                 </@right-col>
               </@top-row>
               <@bottom-row>
-                <div class="col-12 mb-block p-0">
+                <lazarus-skin-page-grid-col modifiers=["full", "no-gutters", "bottom-spacer"]>
                   <lazarus-shared-newsletter-signup-block />
-                </div>
+                </lazarus-skin-page-grid-col>
 
                 <!-- @todo Find a site that implements this position -->
                 <informa-gam-adunit

--- a/packages/lazarus-shared/templates/website-section/index.marko
+++ b/packages/lazarus-shared/templates/website-section/index.marko
@@ -86,6 +86,10 @@ $ const { id, alias, name, pageNode } = data;
                 </@right-col>
               </@top-row>
               <@bottom-row>
+                <div class="col-12 mb-block p-0">
+                  <lazarus-shared-newsletter-signup-block />
+                </div>
+
                 <!-- @todo Find a site that implements this position -->
                 <informa-gam-adunit
                   location="taxonomy"

--- a/packages/lazarus-shared/theme.scss
+++ b/packages/lazarus-shared/theme.scss
@@ -28,8 +28,8 @@ $theme-site-header-breakpoints: (
   small-text-secondary: 1105px
 );
 
-$theme-newsletter-block-bg-color: $theme-lazarus-card-bg-color-dark !default;
-$theme-newsletter-block-button-bg-color: $primary !default;
+$theme-newsletter-block-bg-color: $theme-site-navbar-menu-bg-color !default;
+$theme-newsletter-block-button-bg-color: #c83e31 !default;
 
 // @todo Verify this. Reduced the z-index to prevent overlaying the welcome ad.
 // Currently, the ad template is z-indexing at 20000, so setting this lower.
@@ -459,7 +459,7 @@ $theme-sponsored-content-color: #ee591d !default;
   }
 
   &__submit-button {
-    height: 45px;
+    height: 44px;
     padding: 2px 20px;
     margin-top: auto;
     margin-bottom: auto;
@@ -469,7 +469,7 @@ $theme-sponsored-content-color: #ee591d !default;
     font-weight: 700;
     color: $white;
     text-transform: uppercase;
-    letter-spacing: .1px;
+    letter-spacing: 1px;
     background-color: $theme-newsletter-block-button-bg-color;
     border: none;
   }

--- a/packages/lazarus-shared/theme.scss
+++ b/packages/lazarus-shared/theme.scss
@@ -455,6 +455,7 @@ $theme-sponsored-content-color: #ee591d !default;
     width: 70%;
     height: 45px;
     padding: 2px 20px;
+    font-family: $theme-font-family-serif;
     border: 0;
   }
 

--- a/packages/lazarus-shared/theme.scss
+++ b/packages/lazarus-shared/theme.scss
@@ -28,6 +28,9 @@ $theme-site-header-breakpoints: (
   small-text-secondary: 1105px
 );
 
+$theme-newsletter-block-bg-color: $theme-lazarus-card-bg-color-dark !default;
+$theme-newsletter-block-button-bg-color: $primary !default;
+
 // @todo Verify this. Reduced the z-index to prevent overlaying the welcome ad.
 // Currently, the ad template is z-indexing at 20000, so setting this lower.
 // The default value was 50000
@@ -415,5 +418,59 @@ $theme-sponsored-content-color: #ee591d !default;
 
   &__button {
     margin-top: map-get($spacers, block);
+  }
+}
+
+.newsletter-signup-block {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  padding: $grid-gutter-width * 2;
+  background-color: $theme-newsletter-block-bg-color;
+
+  &__title {
+    @include theme-line-height-crop(1.5);
+    margin-right: auto;
+    margin-bottom: 20px;
+    margin-left: auto;
+    font-size: 22px;
+    font-weight: 600;
+    line-height: 1.5;
+    color: $white;
+    text-align: center;
+  }
+
+  &__form {
+    width: 100%;
+  }
+
+  &__field-wrapper {
+    width: 85%;
+    margin-right: auto;
+    margin-left: auto;
+    text-align: center;
+  }
+
+  &__email-field {
+    width: 70%;
+    height: 45px;
+    padding: 2px 20px;
+    border: 0;
+  }
+
+  &__submit-button {
+    height: 45px;
+    padding: 2px 20px;
+    margin-top: auto;
+    margin-bottom: auto;
+    margin-left: 10px;
+    font-family: Raleway, sans-serif;
+    font-size: 15px;
+    font-weight: 700;
+    color: $white;
+    text-transform: uppercase;
+    letter-spacing: .1px;
+    background-color: $theme-newsletter-block-button-bg-color;
+    border: none;
   }
 }

--- a/packages/lazarus-shared/theme.scss
+++ b/packages/lazarus-shared/theme.scss
@@ -205,6 +205,11 @@ $theme-sponsored-content-color: #ee591d !default;
     &--content-page {
       padding-top: $grid-gutter-width;
     }
+
+    &--no-gutters {
+      padding-right: 0;
+      padding-left: 0;
+    }
   }
 }
 

--- a/sites/americanmachinist.com/config/dragon-forms.js
+++ b/sites/americanmachinist.com/config/dragon-forms.js
@@ -1,0 +1,9 @@
+const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
+
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+
+// config
+//   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })
+//   .addForm('magazineSignup', { omedasite: 'PEN6133_ASland' });
+
+module.exports = config;

--- a/sites/americanmachinist.com/config/dragon-forms.js
+++ b/sites/americanmachinist.com/config/dragon-forms.js
@@ -1,6 +1,6 @@
 const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
 
-const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com' });
 
 // config
 //   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })

--- a/sites/americanmachinist.com/config/navigation.js
+++ b/sites/americanmachinist.com/config/navigation.js
@@ -1,3 +1,5 @@
+const dragonForms = require('./dragon-forms');
+
 module.exports = {
   tertiary: {
     items: [
@@ -32,8 +34,8 @@ module.exports = {
       items: [
         { href: '/webinars', label: 'Webinars' },
         { href: '/white-papers', label: 'White Papers' },
-        // { href: '#', label: 'Magazine Subscription', target: '_blank' },
-        // { href: '#', label: 'eNewlsetter Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewlsetter Subscription', target: '_blank' },
         { href: '/page/contact-us', label: 'Contact Us' },
         { href: 'https://designmanufacturing.informa.com/american-machinist', label: 'Advertise' },
         { href: 'https://www.endeavorbusinessmedia.com/privacy-policy', label: 'Privacy & Cookie Policy', target: '_blank' },

--- a/sites/americanmachinist.com/config/site.js
+++ b/sites/americanmachinist.com/config/site.js
@@ -1,8 +1,10 @@
 const navigation = require('./navigation');
+const dragonForms = require('./dragon-forms');
 
 module.exports = {
   company: 'Endeavor Business Media, LLC',
   navigation,
+  dragonForms,
   homePageSections: [
     { alias: 'machining-cutting', name: 'Machining / Cutting' },
     { alias: 'shop-operations', name: 'Shop Operations' },
@@ -37,5 +39,5 @@ module.exports = {
   wufoo: {
     userName: 'cygnuscorporate',
   },
-  newsletterSubscribeLink: 'https://mfg.informabi.com/LP=2230',
+  newsletterSubscribeLink: dragonForms.getFormUrl('newsletterSignup'),
 };

--- a/sites/asumag.com/config/dragon-forms.js
+++ b/sites/asumag.com/config/dragon-forms.js
@@ -1,0 +1,9 @@
+const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
+
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+
+config
+  .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })
+  .addForm('magazineSignup', { omedasite: 'PEN6133_ASland' });
+
+module.exports = config;

--- a/sites/asumag.com/config/dragon-forms.js
+++ b/sites/asumag.com/config/dragon-forms.js
@@ -1,6 +1,6 @@
 const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
 
-const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com' });
 
 config
   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })

--- a/sites/asumag.com/config/navigation.js
+++ b/sites/asumag.com/config/navigation.js
@@ -34,7 +34,7 @@ module.exports = {
     {
       modifiers: ['secondary'],
       items: [
-        { href: '/awards', label: 'Awards & Competitions' },
+        { href: '/page/awards', label: 'Awards & Competitions' },
         { href: '/magazine-issues/american-school-and-university', label: 'AS&U Magazine' },
         { href: '/american-school-university-digital-edition-archive', label: 'AS&U Digital Editions' },
         { href: 'http://schooldesigns.com', label: 'SchoolDesigns.com', target: '_blank' },

--- a/sites/asumag.com/config/navigation.js
+++ b/sites/asumag.com/config/navigation.js
@@ -1,3 +1,5 @@
+const dragonForms = require('./dragon-forms');
+
 module.exports = {
   tertiary: {
     items: [
@@ -41,8 +43,8 @@ module.exports = {
         { href: '/resources/white-papers', label: 'White Papers' },
         { href: '/page/about-us', label: 'About Us' },
         { href: 'https://buildings.informa.com/american-school-and-university/', label: 'Advertise', target: '_blank' },
-        { href: 'https://endeavor.dragonforms.com/loading.do?omedasite=ASUnewpref', label: 'Newsletters', target: '_blank' },
-        { href: 'https://informa.dragonforms.com/loading.do?omedasite=PEN6133_ASland', label: 'Subscribe', target: '_blank' },
+        { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewlsetter Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
         { href: 'https://www.endeavorbusinessmedia.com/privacy-policy', label: 'Privacy & Cookie Policy', target: '_blank' },
         { href: 'https://www.endeavorbusinessmedia.com/endeavor-terms', label: 'Terms of Service', target: '_blank' },
         { href: 'http://www.penton.com/privacy-policy#ThirdPartyAdvertisingTech', label: 'Ad Choices', target: '_blank' },

--- a/sites/asumag.com/config/site.js
+++ b/sites/asumag.com/config/site.js
@@ -1,8 +1,10 @@
 const navigation = require('./navigation');
+const dragonForms = require('./dragon-forms');
 
 module.exports = {
   company: 'Endeavor Business Media, LLC',
   navigation,
+  dragonForms,
   homePageSections: [
     { alias: 'green', name: 'Green' },
     { alias: 'planning-design', name: 'Planning & Design' },
@@ -36,5 +38,5 @@ module.exports = {
   wufoo: {
     userName: 'cygnuscorporate',
   },
-  newsletterSubscribeLink: 'https://endeavor.dragonforms.com/loading.do?omedasite=ASUnewpref',
+  newsletterSubscribeLink: dragonForms.getFormUrl('newsletterSignup'),
 };

--- a/sites/bulktransporter.com/config/dragon-forms.js
+++ b/sites/bulktransporter.com/config/dragon-forms.js
@@ -1,0 +1,9 @@
+const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
+
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+
+// config
+//   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })
+//   .addForm('magazineSignup', { omedasite: 'PEN6133_ASland' });
+
+module.exports = config;

--- a/sites/bulktransporter.com/config/dragon-forms.js
+++ b/sites/bulktransporter.com/config/dragon-forms.js
@@ -1,6 +1,6 @@
 const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
 
-const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com' });
 
 // config
 //   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })

--- a/sites/bulktransporter.com/config/navigation.js
+++ b/sites/bulktransporter.com/config/navigation.js
@@ -1,3 +1,5 @@
+const dragonForms = require('./dragon-forms');
+
 module.exports = {
   tertiary: {
     items: [
@@ -32,8 +34,8 @@ module.exports = {
       items: [
         { href: '/webinars', label: 'Webinars' },
         { href: '/white-papers', label: 'White Papers' },
-        // { href: '#', label: 'Magazine Subscription', target: '_blank' },
-        // { href: '#', label: 'eNewlsetter Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewlsetter Subscription', target: '_blank' },
         { href: '/page/contact-us', label: 'Contact Us' },
         { href: 'https://cv.informa.com/bulk-transporter/', label: 'Advertise' },
         { href: 'https://www.endeavorbusinessmedia.com/privacy-policy', label: 'Privacy & Cookie Policy', target: '_blank' },

--- a/sites/bulktransporter.com/config/site.js
+++ b/sites/bulktransporter.com/config/site.js
@@ -1,8 +1,10 @@
 const navigation = require('./navigation');
+const dragonForms = require('./dragon-forms');
 
 module.exports = {
   company: 'Endeavor Business Media, LLC',
   navigation,
+  dragonForms,
   homePageSections: [
     { alias: 'equipment', name: 'Equipment' },
     { alias: 'technology', name: 'Technology' },
@@ -36,5 +38,5 @@ module.exports = {
   wufoo: {
     userName: 'cygnuscorporate',
   },
-  newsletterSubscribeLink: 'https://tr.informabi.com/LP=1295',
+  newsletterSubscribeLink: dragonForms.getFormUrl('newsletterSignup'),
 };

--- a/sites/contractingbusiness.com/config/dragon-forms.js
+++ b/sites/contractingbusiness.com/config/dragon-forms.js
@@ -1,6 +1,6 @@
 const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
 
-const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com' });
 
 config
   .addOmedaSite('newsletterSignup', { omedasite: 'CBnewpref' })

--- a/sites/contractingbusiness.com/config/dragon-forms.js
+++ b/sites/contractingbusiness.com/config/dragon-forms.js
@@ -1,0 +1,9 @@
+const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
+
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+
+config
+  .addOmedaSite('newsletterSignup', { omedasite: 'CBnewpref' })
+  .addOmedaSite('magazineSignup', { omedasite: 'PEN6056_GBland' });
+
+module.exports = config;

--- a/sites/contractingbusiness.com/config/navigation.js
+++ b/sites/contractingbusiness.com/config/navigation.js
@@ -1,3 +1,5 @@
+const dragonForms = require('./dragon-forms');
+
 module.exports = {
   tertiary: {
     items: [
@@ -42,8 +44,8 @@ module.exports = {
         { href: '/contracting-business-industry-experts-and-advisors', label: 'Industry Experts and Advisors' },
         { href: '/page/about-us', label: 'About Us' },
         { href: 'https://buildings.informa.com/contracting-business/', label: 'Advertise', target: '_blank' },
-        { href: 'https://endeavor.dragonforms.com/loading.do?omedasite=CBnewpref', label: 'Newsletters', target: '_blank' },
-        { href: 'https://informa.dragonforms.com/loading.do?omedasite=PEN6056_GBland', label: 'Subscribe', target: '_blank' },
+        { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewlsetter Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
         { href: 'https://www.endeavorbusinessmedia.com/privacy-policy', label: 'Privacy & Cookie Policy', target: '_blank' },
         { href: 'https://www.endeavorbusinessmedia.com/endeavor-terms', label: 'Terms of Service', target: '_blank' },
         { href: 'http://www.penton.com/privacy-policy#ThirdPartyAdvertisingTech', label: 'Ad Choices', target: '_blank' },

--- a/sites/contractingbusiness.com/config/site.js
+++ b/sites/contractingbusiness.com/config/site.js
@@ -1,8 +1,10 @@
 const navigation = require('./navigation');
+const dragonForms = require('./dragon-forms');
 
 module.exports = {
   company: 'Endeavor Business Media, LLC',
   navigation,
+  dragonForms,
   homePageSections: [
     { alias: 'columns', name: 'Columns' },
     { alias: 'contracting-business-success', name: 'Contracting Business Success' },
@@ -37,5 +39,5 @@ module.exports = {
   wufoo: {
     userName: 'cygnuscorporate',
   },
-  newsletterSubscribeLink: 'https://endeavor.dragonforms.com/loading.do?omedasite=CBnewpref',
+  newsletterSubscribeLink: dragonForms.getFormUrl('newsletterSignup'),
 };

--- a/sites/contractormag.com/config/dragon-forms.js
+++ b/sites/contractormag.com/config/dragon-forms.js
@@ -1,0 +1,9 @@
+const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
+
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+
+config
+  .addOmedaSite('newsletterSignup', { omedasite: 'CONTRnewpref' })
+  .addOmedaSite('magazineSignup', { omedasite: 'PEN6058_TOland' });
+
+module.exports = config;

--- a/sites/contractormag.com/config/dragon-forms.js
+++ b/sites/contractormag.com/config/dragon-forms.js
@@ -1,6 +1,6 @@
 const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
 
-const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com' });
 
 config
   .addOmedaSite('newsletterSignup', { omedasite: 'CONTRnewpref' })

--- a/sites/contractormag.com/config/navigation.js
+++ b/sites/contractormag.com/config/navigation.js
@@ -1,3 +1,5 @@
+const dragonForms = require('./dragon-forms');
+
 module.exports = {
   tertiary: {
     items: [
@@ -37,9 +39,9 @@ module.exports = {
         { href: '/page/contractor-industry-experts-and-advisors', label: 'Industry Experts and Advisors' },
         { href: '/about-us', label: 'About Us' },
         { href: 'https://buildings.informa.com/contractor/', label: 'Advertise', target: '_blank' },
-        { href: 'https://endeavor.dragonforms.com/loading.do?omedasite=CONTRnewpref', label: 'Newsletters', target: '_blank' },
+        { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewlsetter Subscription', target: '_blank' },
         { href: '/learning-resources', label: 'Learning Resources' },
-        { href: 'https://informa.dragonforms.com/loading.do?omedasite=PEN6058_TOland', label: 'Subscribe' },
+        { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
         { href: 'https://www.endeavorbusinessmedia.com/privacy-policy', label: 'Privacy & Cookie Policy', target: '_blank' },
         { href: 'https://www.endeavorbusinessmedia.com/endeavor-terms', label: 'Terms of Service', target: '_blank' },
         { href: 'http://www.penton.com/privacy-policy#ThirdPartyAdvertisingTech', label: 'Ad Choices', target: '_blank' },

--- a/sites/contractormag.com/config/site.js
+++ b/sites/contractormag.com/config/site.js
@@ -1,8 +1,10 @@
 const navigation = require('./navigation');
+const dragonForms = require('./dragon-forms');
 
 module.exports = {
   company: 'Endeavor Business Media, LLC',
   navigation,
+  dragonForms,
   homePageSections: [
     { alias: 'plumbing', name: 'Plumbing' },
     { alias: 'technology', name: 'Technology' },
@@ -38,5 +40,5 @@ module.exports = {
   wufoo: {
     userName: 'cygnuscorporate',
   },
-  newsletterSubscribeLink: 'https://informa.dragonforms.com/loading.do?omedasite=PEN6058_TOland',
+  newsletterSubscribeLink: dragonForms.getFormUrl('newsletterSignup'),
 };

--- a/sites/ecmweb.com/config/dragon-forms.js
+++ b/sites/ecmweb.com/config/dragon-forms.js
@@ -1,0 +1,9 @@
+const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
+
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+
+config
+  .addOmedaSite('newsletterSignup', { omedasite: 'ECMnewpref' })
+  .addOmedaSite('magazineSignup', { omedasite: 'PEN6132_EBland' });
+
+module.exports = config;

--- a/sites/ecmweb.com/config/dragon-forms.js
+++ b/sites/ecmweb.com/config/dragon-forms.js
@@ -1,6 +1,6 @@
 const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
 
-const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com' });
 
 config
   .addOmedaSite('newsletterSignup', { omedasite: 'ECMnewpref' })

--- a/sites/ecmweb.com/config/navigation.js
+++ b/sites/ecmweb.com/config/navigation.js
@@ -1,3 +1,5 @@
+const dragonForms = require('./dragon-forms');
+
 module.exports = {
   tertiary: {
     items: [
@@ -47,8 +49,8 @@ module.exports = {
         { href: '/ecm-digital-editions', label: 'Digital Editions Archive' },
         { href: '/page/about-us', label: 'About Us' },
         { href: 'https://buildings.informa.com/ecm', label: 'Advertise', target: '_blank' },
-        { href: 'https://endeavor.dragonforms.com/loading.do?omedasite=ECMnewpref', label: 'Newsletters' },
-        { href: 'https://informa.dragonforms.com/loading.do?omedasite=PEN6132_EBland', label: 'Subscribe', target: '_blank' },
+        { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewlsetter Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
         { href: 'https://www.endeavorbusinessmedia.com/privacy-policy', label: 'Privacy & Cookie Policy', target: '_blank' },
         { href: 'https://www.endeavorbusinessmedia.com/endeavor-terms', label: 'Terms of Service', target: '_blank' },
         { href: 'http://www.penton.com/privacy-policy#ThirdPartyAdvertisingTech', label: 'Ad Choices', target: '_blank' },

--- a/sites/ecmweb.com/config/site.js
+++ b/sites/ecmweb.com/config/site.js
@@ -1,8 +1,10 @@
 const navigation = require('./navigation');
+const dragonForms = require('./dragon-forms');
 
 module.exports = {
   company: 'Endeavor Business Media, LLC',
   navigation,
+  dragonForms,
   homePageSections: [
     { alias: 'design', name: 'Design' },
     { alias: 'maintenance-repair-operations', name: 'Maintenance, Repair & Operations' },
@@ -38,5 +40,5 @@ module.exports = {
   wufoo: {
     userName: 'cygnuscorporate',
   },
-  newsletterSubscribeLink: 'https://endeavor.dragonforms.com/loading.do?omedasite=ECMnewpref',
+  newsletterSubscribeLink: dragonForms.getFormUrl('newsletterSignup'),
 };

--- a/sites/ehstoday.com/config/dragon-forms.js
+++ b/sites/ehstoday.com/config/dragon-forms.js
@@ -1,0 +1,9 @@
+const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
+
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+
+// config
+//   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })
+//   .addForm('magazineSignup', { omedasite: 'PEN6133_ASland' });
+
+module.exports = config;

--- a/sites/ehstoday.com/config/dragon-forms.js
+++ b/sites/ehstoday.com/config/dragon-forms.js
@@ -1,6 +1,6 @@
 const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
 
-const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com' });
 
 // config
 //   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })

--- a/sites/ehstoday.com/config/navigation.js
+++ b/sites/ehstoday.com/config/navigation.js
@@ -1,3 +1,5 @@
+const dragonForms = require('./dragon-forms');
+
 module.exports = {
   tertiary: {
     items: [
@@ -36,8 +38,8 @@ module.exports = {
       items: [
         { href: '/webinars', label: 'Webinars' },
         { href: '/white-papers', label: 'White Papers' },
-        // { href: '#', label: 'Magazine Subscription', target: '_blank' },
-        // { href: '#', label: 'eNewlsetter Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewlsetter Subscription', target: '_blank' },
         { href: '/page/contact-us', label: 'Contact Us' },
         { href: 'https://designmanufacturing.informa.com/ehs-today', label: 'Advertise' },
         { href: 'https://www.endeavorbusinessmedia.com/privacy-policy', label: 'Privacy & Cookie Policy', target: '_blank' },

--- a/sites/ehstoday.com/config/site.js
+++ b/sites/ehstoday.com/config/site.js
@@ -1,8 +1,10 @@
 const navigation = require('./navigation');
+const dragonForms = require('./dragon-forms');
 
 module.exports = {
   company: 'Endeavor Business Media, LLC',
   navigation,
+  dragonForms,
   homePageSections: [
     { alias: 'safety', name: 'Safety' },
     { alias: 'safety-technology', name: 'Safety Technology' },
@@ -37,5 +39,5 @@ module.exports = {
   wufoo: {
     userName: 'cygnuscorporate',
   },
-  newsletterSubscribeLink: 'https://mfg.informabi.com/LP=1852',
+  newsletterSubscribeLink: dragonForms.getFormUrl('newsletterSignup'),
 };

--- a/sites/electricalmarketing.com/config/dragon-forms.js
+++ b/sites/electricalmarketing.com/config/dragon-forms.js
@@ -1,6 +1,6 @@
 const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
 
-const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com' });
 
 config
   .addOmedaSite('newsletterSignup', { omedasite: 'EMNewPref' })

--- a/sites/electricalmarketing.com/config/dragon-forms.js
+++ b/sites/electricalmarketing.com/config/dragon-forms.js
@@ -1,0 +1,9 @@
+const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
+
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+
+config
+  .addOmedaSite('newsletterSignup', { omedasite: 'EMNewPref' })
+  .addOmedaSite('magazineSignup', { omedasite: 'PEN6149_JEland' });
+
+module.exports = config;

--- a/sites/electricalmarketing.com/config/navigation.js
+++ b/sites/electricalmarketing.com/config/navigation.js
@@ -1,3 +1,5 @@
+const dragonForms = require('./dragon-forms');
+
 module.exports = {
   tertiary: {
     items: [
@@ -37,8 +39,8 @@ module.exports = {
         { href: '/market-segments/utility', label: 'Utility Market' },
         { href: '/page/about-us', label: 'About Us' },
         { href: 'http://ebmarketing.penton.com/brands/electrical-marketing/', label: 'Advertise', target: '_blank' },
-        { href: 'https://endeavor.dragonforms.com/loading.do?omedasite=EMNewPref', label: 'Newsletters', target: '_blank' },
-        { href: 'https://informa.dragonforms.com/loading.do?omedasite=PEN6149_JEland', label: 'Subscribe', target: '_blank' },
+        { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewlsetter Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
         { href: 'https://www.endeavorbusinessmedia.com/privacy-policy', label: 'Privacy & Cookie Policy', target: '_blank' },
         { href: 'https://www.endeavorbusinessmedia.com/endeavor-terms', label: 'Terms of Service', target: '_blank' },
         { href: 'http://www.penton.com/privacy-policy#ThirdPartyAdvertisingTech', label: 'Ad Choices', target: '_blank' },

--- a/sites/electricalmarketing.com/config/site.js
+++ b/sites/electricalmarketing.com/config/site.js
@@ -1,8 +1,10 @@
 const navigation = require('./navigation');
+const dragonForms = require('./dragon-forms');
 
 module.exports = {
   company: 'Endeavor Business Media, LLC',
   navigation,
+  dragonForms,
   homePageSections: [
     { alias: 'industry-stats', name: 'Industry Stats' },
     { alias: 'hot-topics', name: 'Hot Topics' },
@@ -35,5 +37,5 @@ module.exports = {
   wufoo: {
     userName: 'cygnuscorporate',
   },
-  newsletterSubscribeLink: 'https://endeavor.dragonforms.com/loading.do?omedasite=EMNewPref',
+  newsletterSubscribeLink: dragonForms.getFormUrl('newsletterSignup'),
 };

--- a/sites/electronicdesign.com/config/dragon-forms.js
+++ b/sites/electronicdesign.com/config/dragon-forms.js
@@ -1,0 +1,9 @@
+const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
+
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+
+config
+  .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })
+  .addForm('magazineSignup', { omedasite: 'PEN6133_ASland' });
+
+module.exports = config;

--- a/sites/electronicdesign.com/config/dragon-forms.js
+++ b/sites/electronicdesign.com/config/dragon-forms.js
@@ -2,8 +2,8 @@ const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/confi
 
 const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
 
-config
-  .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })
-  .addForm('magazineSignup', { omedasite: 'PEN6133_ASland' });
+// config
+//   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })
+//   .addForm('magazineSignup', { omedasite: 'PEN6133_ASland' });
 
 module.exports = config;

--- a/sites/electronicdesign.com/config/dragon-forms.js
+++ b/sites/electronicdesign.com/config/dragon-forms.js
@@ -1,6 +1,6 @@
 const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
 
-const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com' });
 
 // config
 //   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })

--- a/sites/electronicdesign.com/config/navigation.js
+++ b/sites/electronicdesign.com/config/navigation.js
@@ -1,3 +1,5 @@
+const dragonForms = require('./dragon-forms');
+
 module.exports = {
   tertiary: {
     items: [
@@ -33,8 +35,8 @@ module.exports = {
       items: [
         { href: '/webinars', label: 'Webinars' },
         { href: '/white-papers', label: 'White Papers' },
-        // { href: '#', label: 'Magazine Subscription', target: '_blank' },
-        // { href: '#', label: 'eNewlsetter Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewlsetter Subscription', target: '_blank' },
         { href: '/page/contact-us', label: 'Contact Us' },
         { href: 'https://designengineering.informa.com/electronic-design/', label: 'Advertise' },
         { href: 'https://www.endeavorbusinessmedia.com/privacy-policy', label: 'Privacy & Cookie Policy', target: '_blank' },

--- a/sites/electronicdesign.com/config/site.js
+++ b/sites/electronicdesign.com/config/site.js
@@ -1,8 +1,10 @@
 const navigation = require('./navigation');
+const dragonForms = require('./dragon-forms');
 
 module.exports = {
   company: 'Endeavor Business Media, LLC',
   navigation,
+  dragonForms,
   homePageSections: [
     { alias: 'industrial-automation', name: 'Industrial Automation' },
     { alias: 'markets/automotive', name: 'Automotive' },
@@ -37,5 +39,5 @@ module.exports = {
   wufoo: {
     userName: 'cygnuscorporate',
   },
-  newsletterSubscribeLink: 'https://design.informabi.com/LP=2980',
+  newsletterSubscribeLink: dragonForms.getFormUrl('newsletterSignup'),
 };

--- a/sites/ewweb.com/config/dragon-forms.js
+++ b/sites/ewweb.com/config/dragon-forms.js
@@ -1,0 +1,9 @@
+const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
+
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+
+config
+  .addOmedaSite('newsletterSignup', { omedasite: 'EWnewpref' })
+  .addOmedaSite('magazineSignup', { omedasite: 'PEN6111_EWland' });
+
+module.exports = config;

--- a/sites/ewweb.com/config/dragon-forms.js
+++ b/sites/ewweb.com/config/dragon-forms.js
@@ -1,6 +1,6 @@
 const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
 
-const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com' });
 
 config
   .addOmedaSite('newsletterSignup', { omedasite: 'EWnewpref' })

--- a/sites/ewweb.com/config/navigation.js
+++ b/sites/ewweb.com/config/navigation.js
@@ -1,3 +1,5 @@
+const dragonForms = require('./dragon-forms');
+
 module.exports = {
   tertiary: {
     items: [
@@ -39,8 +41,8 @@ module.exports = {
         { href: '/webinars', label: 'Webinars' },
         { href: '/page/about-us', label: 'About Us' },
         { href: 'https://buildings.informa.com/electrical-wholesaling/', label: 'Advertise', target: '_blank' },
-        { href: 'https://endeavor.dragonforms.com/loading.do?omedasite=EWnewpref', label: 'Newsletters', target: '_blank' },
-        { href: 'https://informa.dragonforms.com/loading.do?omedasite=PEN6111_EWland', label: 'Subscribe', target: '_blank' },
+        { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewlsetter Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
         { href: 'https://www.endeavorbusinessmedia.com/privacy-policy', label: 'Privacy & Cookie Policy', target: '_blank' },
         { href: 'https://www.endeavorbusinessmedia.com/endeavor-terms', label: 'Terms of Service', target: '_blank' },
         { href: 'http://www.penton.com/privacy-policy#ThirdPartyAdvertisingTech', label: 'Ad Choices', target: '_blank' },

--- a/sites/ewweb.com/config/site.js
+++ b/sites/ewweb.com/config/site.js
@@ -1,8 +1,10 @@
 const navigation = require('./navigation');
+const dragonForms = require('./dragon-forms');
 
 module.exports = {
   company: 'Endeavor Business Media, LLC',
   navigation,
+  dragonForms,
   homePageSections: [
     { alias: 'news/people', name: 'People' },
     { alias: 'electrical-economy', name: 'Electrical Economy' },
@@ -37,5 +39,5 @@ module.exports = {
   wufoo: {
     userName: 'cygnuscorporate',
   },
-  newsletterSubscribeLink: 'https://endeavor.dragonforms.com/loading.do?omedasite=EWnewpref',
+  newsletterSubscribeLink: dragonForms.getFormUrl('newsletterSignup'),
 };

--- a/sites/fleetowner.com/config/dragon-forms.js
+++ b/sites/fleetowner.com/config/dragon-forms.js
@@ -1,0 +1,9 @@
+const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
+
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+
+config
+  // .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })
+  .addForm('magazineSignup', { omedasite: 'PEN6124_FRnew' });
+
+module.exports = config;

--- a/sites/fleetowner.com/config/dragon-forms.js
+++ b/sites/fleetowner.com/config/dragon-forms.js
@@ -1,6 +1,6 @@
 const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
 
-const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com' });
 
 config
   // .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })

--- a/sites/fleetowner.com/config/navigation.js
+++ b/sites/fleetowner.com/config/navigation.js
@@ -1,3 +1,5 @@
+const dragonForms = require('./dragon-forms');
+
 module.exports = {
   tertiary: {
     items: [
@@ -33,8 +35,8 @@ module.exports = {
       items: [
         { href: '/webinars', label: 'Webinars' },
         { href: '/white-papers', label: 'White Papers' },
-        { href: 'https://informa.dragonforms.com/loading.do?pk=web2&omedasite=PEN6124_FRnew', label: 'Magazine Subscription', target: '_blank' },
-        // { href: '#', label: 'eNewlsetter Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewlsetter Subscription', target: '_blank' },
         { href: '/page/contact-us', label: 'Contact Us' },
         { href: 'https://cv.informa.com/fleet-owner/', label: 'Advertise' },
         { href: 'https://www.endeavorbusinessmedia.com/privacy-policy', label: 'Privacy & Cookie Policy', target: '_blank' },

--- a/sites/fleetowner.com/config/navigation.js
+++ b/sites/fleetowner.com/config/navigation.js
@@ -34,7 +34,7 @@ module.exports = {
         { href: '/webinars', label: 'Webinars' },
         { href: '/white-papers', label: 'White Papers' },
         { href: 'https://informa.dragonforms.com/loading.do?pk=web2&omedasite=PEN6124_FRnew', label: 'Magazine Subscription', target: '_blank' },
-        { href: '#', label: 'eNewlsetter Subscription', target: '_blank' },
+        // { href: '#', label: 'eNewlsetter Subscription', target: '_blank' },
         { href: '/page/contact-us', label: 'Contact Us' },
         { href: 'https://cv.informa.com/fleet-owner/', label: 'Advertise' },
         { href: 'https://www.endeavorbusinessmedia.com/privacy-policy', label: 'Privacy & Cookie Policy', target: '_blank' },

--- a/sites/fleetowner.com/config/site.js
+++ b/sites/fleetowner.com/config/site.js
@@ -1,8 +1,10 @@
 const navigation = require('./navigation');
+const dragonForms = require('./dragon-forms');
 
 module.exports = {
   company: 'Endeavor Business Media, LLC',
   navigation,
+  dragonForms,
   homePageSections: [
     { alias: 'safety', name: 'Safety' },
     { alias: 'equipment', name: 'Equipment' },
@@ -37,5 +39,5 @@ module.exports = {
   wufoo: {
     userName: 'cygnuscorporate',
   },
-  newsletterSubscribeLink: 'https://tr.informabi.com/LP=1381',
+  newsletterSubscribeLink: dragonForms.getFormUrl('newsletterSignup'),
 };

--- a/sites/forgingmagazine.com/config/dragon-forms.js
+++ b/sites/forgingmagazine.com/config/dragon-forms.js
@@ -1,0 +1,9 @@
+const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
+
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+
+// config
+//   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })
+//   .addForm('magazineSignup', { omedasite: 'PEN6133_ASland' });
+
+module.exports = config;

--- a/sites/forgingmagazine.com/config/dragon-forms.js
+++ b/sites/forgingmagazine.com/config/dragon-forms.js
@@ -1,6 +1,6 @@
 const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
 
-const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com' });
 
 // config
 //   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })

--- a/sites/forgingmagazine.com/config/navigation.js
+++ b/sites/forgingmagazine.com/config/navigation.js
@@ -1,3 +1,5 @@
+const dragonForms = require('./dragon-forms');
+
 module.exports = {
   tertiary: {
     items: [
@@ -33,8 +35,8 @@ module.exports = {
       items: [
         { href: '/webinars', label: 'Webinars' },
         { href: '/white-papers', label: 'White Papers' },
-        // { href: '#', label: 'Magazine Subscription', target: '_blank' },
-        // { href: '#', label: 'eNewlsetter Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewlsetter Subscription', target: '_blank' },
         { href: '/page/contact-us', label: 'Contact Us' },
         { href: 'https://designmanufacturing.informa.com/forging/', label: 'Advertise' },
         { href: 'https://www.endeavorbusinessmedia.com/privacy-policy', label: 'Privacy & Cookie Policy', target: '_blank' },

--- a/sites/forgingmagazine.com/config/site.js
+++ b/sites/forgingmagazine.com/config/site.js
@@ -1,8 +1,10 @@
 const navigation = require('./navigation');
+const dragonForms = require('./dragon-forms');
 
 module.exports = {
   company: 'Endeavor Business Media, LLC',
   navigation,
+  dragonForms,
   homePageSections: [
     { alias: 'forming', name: 'Forming' },
     { alias: 'heating', name: 'Heating' },
@@ -36,5 +38,5 @@ module.exports = {
   wufoo: {
     userName: 'cygnuscorporate',
   },
-  newsletterSubscribeLink: 'https://mfg.informabi.com/LP=1898',
+  newsletterSubscribeLink: dragonForms.getFormUrl('newsletterSignup'),
 };

--- a/sites/foundrymag.com/config/dragon-forms.js
+++ b/sites/foundrymag.com/config/dragon-forms.js
@@ -1,0 +1,9 @@
+const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
+
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+
+// config
+//   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })
+//   .addForm('magazineSignup', { omedasite: 'PEN6133_ASland' });
+
+module.exports = config;

--- a/sites/foundrymag.com/config/dragon-forms.js
+++ b/sites/foundrymag.com/config/dragon-forms.js
@@ -1,6 +1,6 @@
 const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
 
-const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com' });
 
 // config
 //   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })

--- a/sites/foundrymag.com/config/navigation.js
+++ b/sites/foundrymag.com/config/navigation.js
@@ -1,3 +1,5 @@
+const dragonForms = require('./dragon-forms');
+
 module.exports = {
   tertiary: {
     items: [
@@ -34,8 +36,8 @@ module.exports = {
       items: [
         { href: '/webinars', label: 'Webinars' },
         { href: '/white-papers', label: 'White Papers' },
-        // { href: '#', label: 'Magazine Subscription', target: '_blank' },
-        // { href: '#', label: 'eNewlsetter Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewlsetter Subscription', target: '_blank' },
         { href: '/page/contact-us', label: 'Contact Us' },
         { href: 'https://designmanufacturing.informa.com/foundry/', label: 'Advertise' },
         { href: 'https://www.endeavorbusinessmedia.com/privacy-policy', label: 'Privacy & Cookie Policy', target: '_blank' },

--- a/sites/foundrymag.com/config/site.js
+++ b/sites/foundrymag.com/config/site.js
@@ -1,8 +1,10 @@
 const navigation = require('./navigation');
+const dragonForms = require('./dragon-forms');
 
 module.exports = {
   company: 'Endeavor Business Media, LLC',
   navigation,
+  dragonForms,
   homePageSections: [
     { alias: 'ask-the-expert', name: 'Ask the Expert' },
     { alias: 'molds-cores', name: 'Molds/Cores' },
@@ -36,5 +38,5 @@ module.exports = {
   wufoo: {
     userName: 'cygnuscorporate',
   },
-  newsletterSubscribeLink: 'https://mfg.informabi.com/LP=1894',
+  newsletterSubscribeLink: dragonForms.getFormUrl('newsletterSignup'),
 };

--- a/sites/hpac.com/config/dragon-forms.js
+++ b/sites/hpac.com/config/dragon-forms.js
@@ -1,0 +1,9 @@
+const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
+
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+
+config
+  .addOmedaSite('newsletterSignup', { omedasite: 'HPACnewpref' })
+  .addOmedaSite('magazineSignup', { omedasite: 'PEN6057_HRland' });
+
+module.exports = config;

--- a/sites/hpac.com/config/dragon-forms.js
+++ b/sites/hpac.com/config/dragon-forms.js
@@ -1,6 +1,6 @@
 const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
 
-const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com' });
 
 config
   .addOmedaSite('newsletterSignup', { omedasite: 'HPACnewpref' })

--- a/sites/hpac.com/config/navigation.js
+++ b/sites/hpac.com/config/navigation.js
@@ -1,3 +1,5 @@
+const dragonForms = require('./dragon-forms');
+
 module.exports = {
   tertiary: {
     items: [
@@ -35,8 +37,8 @@ module.exports = {
         { href: '/hpac-engineering-industry-experts-and-advisors', label: 'Industry Experts and Advisors' },
         { href: '/page/about-us', label: 'About Us' },
         { href: 'https://buildings.informa.com/hpac', label: 'Advertise', target: '_blank' },
-        { href: 'https://endeavor.dragonforms.com/loading.do?omedasite=HPACnewpref', label: 'Newsletters', target: '_blank' },
-        { href: 'https://informa.dragonforms.com/loading.do?omedasite=PEN6057_HRland', label: 'Subscribe', target: '_blank' },
+        { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewlsetter Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
         { href: 'https://www.endeavorbusinessmedia.com/privacy-policy', label: 'Privacy & Cookie Policy', target: '_blank' },
         { href: 'https://www.endeavorbusinessmedia.com/endeavor-terms', label: 'Terms of Service', target: '_blank' },
         { href: 'http://www.penton.com/privacy-policy#ThirdPartyAdvertisingTech', label: 'Ad Choices', target: '_blank' },

--- a/sites/hpac.com/config/site.js
+++ b/sites/hpac.com/config/site.js
@@ -1,8 +1,10 @@
 const navigation = require('./navigation');
+const dragonForms = require('./dragon-forms');
 
 module.exports = {
   company: 'Endeavor Business Media, LLC',
   navigation,
+  dragonForms,
   homePageSections: [
     { alias: 'air-conditioning', name: 'Air Conditioning' },
     { alias: 'building-automation', name: 'Building Automation' },
@@ -37,5 +39,5 @@ module.exports = {
   wufoo: {
     userName: 'cygnuscorporate',
   },
-  newsletterSubscribeLink: 'https://endeavor.dragonforms.com/loading.do?omedasite=HPACnewpref',
+  newsletterSubscribeLink: dragonForms.getFormUrl('newsletterSignup'),
 };

--- a/sites/hydraulicspneumatics.com/config/dragon-forms.js
+++ b/sites/hydraulicspneumatics.com/config/dragon-forms.js
@@ -1,0 +1,9 @@
+const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
+
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+
+// config
+//   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })
+//   .addForm('magazineSignup', { omedasite: 'PEN6133_ASland' });
+
+module.exports = config;

--- a/sites/hydraulicspneumatics.com/config/dragon-forms.js
+++ b/sites/hydraulicspneumatics.com/config/dragon-forms.js
@@ -1,6 +1,6 @@
 const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
 
-const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com' });
 
 // config
 //   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })

--- a/sites/hydraulicspneumatics.com/config/navigation.js
+++ b/sites/hydraulicspneumatics.com/config/navigation.js
@@ -1,3 +1,5 @@
+const dragonForms = require('./dragon-forms');
+
 module.exports = {
   tertiary: {
     items: [
@@ -32,8 +34,8 @@ module.exports = {
       items: [
         { href: '/webinars', label: 'Webinars' },
         { href: '/white-papers', label: 'White Papers' },
-        // { href: '#', label: 'Magazine Subscription', target: '_blank' },
-        // { href: '#', label: 'eNewlsetter Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewlsetter Subscription', target: '_blank' },
         { href: '/page/contact-us', label: 'Contact Us' },
         { href: 'https://designengineering.informa.com/hydraulics-pneumatics/', label: 'Advertise' },
         { href: 'https://www.endeavorbusinessmedia.com/privacy-policy', label: 'Privacy & Cookie Policy', target: '_blank' },

--- a/sites/hydraulicspneumatics.com/config/site.js
+++ b/sites/hydraulicspneumatics.com/config/site.js
@@ -1,8 +1,10 @@
 const navigation = require('./navigation');
+const dragonForms = require('./dragon-forms');
 
 module.exports = {
   company: 'Endeavor Business Media, LLC',
   navigation,
+  dragonForms,
   homePageSections: [
     { alias: '/technologies/cylinders-actuators', name: 'Cylinders & Actuators' },
     { alias: 'technologies/hydraulic-valves', name: 'Hydraulic Valves' },
@@ -37,5 +39,5 @@ module.exports = {
   wufoo: {
     userName: 'cygnuscorporate',
   },
-  newsletterSubscribeLink: 'https://design.informabi.com/LP=3633',
+  newsletterSubscribeLink: dragonForms.getFormUrl('newsletterSignup'),
 };

--- a/sites/industryweek.com/config/dragon-forms.js
+++ b/sites/industryweek.com/config/dragon-forms.js
@@ -1,0 +1,9 @@
+const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
+
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+
+config
+  // .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })
+  .addForm('magazineSignup', { omedasite: 'PEN6086_IYnew', query: { pk: 'NNHWEB' } });
+
+module.exports = config;

--- a/sites/industryweek.com/config/dragon-forms.js
+++ b/sites/industryweek.com/config/dragon-forms.js
@@ -1,6 +1,6 @@
 const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
 
-const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com' });
 
 config
   // .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })

--- a/sites/industryweek.com/config/navigation.js
+++ b/sites/industryweek.com/config/navigation.js
@@ -1,3 +1,5 @@
+const dragonForms = require('./dragon-forms');
+
 module.exports = {
   tertiary: {
     items: [
@@ -31,8 +33,8 @@ module.exports = {
       items: [
         { href: '/webinars', label: 'Webinars' },
         { href: '/white-papers', label: 'White Papers' },
-        { href: 'https://informa.dragonforms.com/loading.do?pk=NNHWEB&omedasite=PEN6086_IYnew', label: 'Magazine Subscription', target: '_blank' },
-        // { href: 'https://mfg.informabi.com/LP=1551', label: 'eNewlsetter Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewlsetter Subscription', target: '_blank' },
         { href: '/page/contact-us', label: 'Contact Us' },
         { href: 'https://designmanufacturing.informa.com/industryweek/', label: 'Advertise' },
         { href: 'https://www.endeavorbusinessmedia.com/privacy-policy', label: 'Privacy & Cookie Policy', target: '_blank' },

--- a/sites/industryweek.com/config/navigation.js
+++ b/sites/industryweek.com/config/navigation.js
@@ -32,7 +32,7 @@ module.exports = {
         { href: '/webinars', label: 'Webinars' },
         { href: '/white-papers', label: 'White Papers' },
         { href: 'https://informa.dragonforms.com/loading.do?pk=NNHWEB&omedasite=PEN6086_IYnew', label: 'Magazine Subscription', target: '_blank' },
-        { href: 'https://mfg.informabi.com/LP=1551', label: 'eNewlsetter Subscription', target: '_blank' },
+        // { href: 'https://mfg.informabi.com/LP=1551', label: 'eNewlsetter Subscription', target: '_blank' },
         { href: '/page/contact-us', label: 'Contact Us' },
         { href: 'https://designmanufacturing.informa.com/industryweek/', label: 'Advertise' },
         { href: 'https://www.endeavorbusinessmedia.com/privacy-policy', label: 'Privacy & Cookie Policy', target: '_blank' },

--- a/sites/industryweek.com/config/site.js
+++ b/sites/industryweek.com/config/site.js
@@ -1,8 +1,10 @@
 const navigation = require('./navigation');
+const dragonForms = require('./dragon-forms');
 
 module.exports = {
   company: 'Endeavor Business Media, LLC',
   navigation,
+  dragonForms,
   homePageSections: [
     { alias: 'operations', name: 'Operations' },
     { alias: 'leadership', name: 'Leadership' },
@@ -38,5 +40,5 @@ module.exports = {
   wufoo: {
     userName: 'cygnuscorporate',
   },
-  newsletterSubscribeLink: 'https://mfg.informabi.com/LP=1551',
+  newsletterSubscribeLink: dragonForms.getFormUrl('newsletterSignup'),
 };

--- a/sites/machinedesign.com/config/dragon-forms.js
+++ b/sites/machinedesign.com/config/dragon-forms.js
@@ -1,0 +1,9 @@
+const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
+
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+
+// config
+//   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })
+//   .addForm('magazineSignup', { omedasite: 'PEN6133_ASland' });
+
+module.exports = config;

--- a/sites/machinedesign.com/config/dragon-forms.js
+++ b/sites/machinedesign.com/config/dragon-forms.js
@@ -1,6 +1,6 @@
 const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
 
-const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com' });
 
 // config
 //   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })

--- a/sites/machinedesign.com/config/navigation.js
+++ b/sites/machinedesign.com/config/navigation.js
@@ -1,3 +1,5 @@
+const dragonForms = require('./dragon-forms');
+
 module.exports = {
   tertiary: {
     items: [
@@ -35,8 +37,8 @@ module.exports = {
       items: [
         { href: '/webinars', label: 'Webinars' },
         { href: '/white-papers', label: 'White Papers' },
-        // { href: '#', label: 'Magazine Subscription', target: '_blank' },
-        // { href: '#', label: 'eNewlsetter Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewlsetter Subscription', target: '_blank' },
         { href: '/page/contact-us', label: 'Contact Us' },
         { href: 'https://designengineering.informa.com/machine-design/', label: 'Advertise' },
         { href: 'https://www.endeavorbusinessmedia.com/privacy-policy', label: 'Privacy & Cookie Policy', target: '_blank' },

--- a/sites/machinedesign.com/config/site.js
+++ b/sites/machinedesign.com/config/site.js
@@ -1,8 +1,10 @@
 const navigation = require('./navigation');
+const dragonForms = require('./dragon-forms');
 
 module.exports = {
   company: 'Endeavor Business Media, LLC',
   navigation,
+  dragonForms,
   homePageSections: [
     { alias: 'mechanical-motion-systems', name: 'Mechanical & Motion Systems' },
     { alias: '3d-printing-cad', name: '3D Printing & CAD' },
@@ -37,5 +39,5 @@ module.exports = {
   wufoo: {
     userName: 'cygnuscorporate',
   },
-  newsletterSubscribeLink: 'https://design.informabi.com/LP=3227',
+  newsletterSubscribeLink: dragonForms.getFormUrl('newsletterSignup'),
 };

--- a/sites/mhlnews.com/config/dragon-forms.js
+++ b/sites/mhlnews.com/config/dragon-forms.js
@@ -1,0 +1,9 @@
+const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
+
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+
+// config
+//   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })
+//   .addForm('magazineSignup', { omedasite: 'PEN6133_ASland' });
+
+module.exports = config;

--- a/sites/mhlnews.com/config/dragon-forms.js
+++ b/sites/mhlnews.com/config/dragon-forms.js
@@ -1,6 +1,6 @@
 const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
 
-const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com' });
 
 // config
 //   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })

--- a/sites/mhlnews.com/config/navigation.js
+++ b/sites/mhlnews.com/config/navigation.js
@@ -1,3 +1,5 @@
+const dragonForms = require('./dragon-forms');
+
 module.exports = {
   tertiary: {
     items: [
@@ -32,8 +34,8 @@ module.exports = {
       items: [
         { href: '/webinars', label: 'Webinars' },
         { href: '/white-papers', label: 'White Papers' },
-        // { href: '#', label: 'Magazine Subscription', target: '_blank' },
-        // { href: '#', label: 'eNewlsetter Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewlsetter Subscription', target: '_blank' },
         { href: '/page/contact-us', label: 'Contact Us' },
         { href: 'https://designmanufacturing.informa.com/mhl/', label: 'Advertise' },
         { href: 'https://www.endeavorbusinessmedia.com/privacy-policy', label: 'Privacy & Cookie Policy', target: '_blank' },

--- a/sites/mhlnews.com/config/site.js
+++ b/sites/mhlnews.com/config/site.js
@@ -1,8 +1,10 @@
 const navigation = require('./navigation');
+const dragonForms = require('./dragon-forms');
 
 module.exports = {
   company: 'Endeavor Business Media, LLC',
   navigation,
+  dragonForms,
   homePageSections: [
     { alias: 'transportation-distribution', name: 'Transportation & Distribution' },
     { alias: 'global-supply-chain', name: 'Global Supply Chain' },
@@ -38,5 +40,5 @@ module.exports = {
   wufoo: {
     userName: 'cygnuscorporate',
   },
-  newsletterSubscribeLink: 'https://mfg.informabi.com/LP=1899',
+  newsletterSubscribeLink: dragonForms.getFormUrl('newsletterSignup'),
 };

--- a/sites/mwrf.com/config/dragon-forms.js
+++ b/sites/mwrf.com/config/dragon-forms.js
@@ -1,0 +1,9 @@
+const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
+
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+
+// config
+//   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })
+//   .addForm('magazineSignup', { omedasite: 'PEN6133_ASland' });
+
+module.exports = config;

--- a/sites/mwrf.com/config/dragon-forms.js
+++ b/sites/mwrf.com/config/dragon-forms.js
@@ -1,6 +1,6 @@
 const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
 
-const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com' });
 
 // config
 //   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })

--- a/sites/mwrf.com/config/navigation.js
+++ b/sites/mwrf.com/config/navigation.js
@@ -1,3 +1,5 @@
+const dragonForms = require('./dragon-forms');
+
 module.exports = {
   tertiary: {
     items: [
@@ -34,8 +36,8 @@ module.exports = {
       items: [
         { href: '/webinars', label: 'Webinars' },
         { href: '/white-papers', label: 'White Papers' },
-        // { href: '#', label: 'Magazine Subscription', target: '_blank' },
-        // { href: '#', label: 'eNewlsetter Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewlsetter Subscription', target: '_blank' },
         { href: '/page/contact-us', label: 'Contact Us' },
         { href: 'https://designengineering.informa.com/microwaves-rf/', label: 'Advertise' },
         { href: 'https://www.endeavorbusinessmedia.com/privacy-policy', label: 'Privacy & Cookie Policy', target: '_blank' },

--- a/sites/mwrf.com/config/site.js
+++ b/sites/mwrf.com/config/site.js
@@ -1,8 +1,10 @@
 const navigation = require('./navigation');
+const dragonForms = require('./dragon-forms');
 
 module.exports = {
   company: 'Endeavor Business Media, LLC',
   navigation,
+  dragonForms,
   homePageSections: [
     { alias: 'defense', name: 'Defense' },
     { alias: 'components', name: 'Components' },
@@ -37,5 +39,5 @@ module.exports = {
   wufoo: {
     userName: 'cygnuscorporate',
   },
-  newsletterSubscribeLink: 'https://design.informabi.com/LP=3699',
+  newsletterSubscribeLink: dragonForms.getFormUrl('newsletterSignup'),
 };

--- a/sites/newequipment.com/config/dragon-forms.js
+++ b/sites/newequipment.com/config/dragon-forms.js
@@ -1,0 +1,9 @@
+const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
+
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+
+// config
+//   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })
+//   .addForm('magazineSignup', { omedasite: 'PEN6133_ASland' });
+
+module.exports = config;

--- a/sites/newequipment.com/config/dragon-forms.js
+++ b/sites/newequipment.com/config/dragon-forms.js
@@ -1,6 +1,6 @@
 const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
 
-const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com' });
 
 // config
 //   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })

--- a/sites/newequipment.com/config/navigation.js
+++ b/sites/newequipment.com/config/navigation.js
@@ -1,3 +1,5 @@
+const dragonForms = require('./dragon-forms');
+
 module.exports = {
   tertiary: {
     items: [
@@ -31,8 +33,8 @@ module.exports = {
       items: [
         { href: '/webinars', label: 'Webinars' },
         { href: '/white-papers', label: 'White Papers' },
-        // { href: '#', label: 'Magazine Subscription', target: '_blank' },
-        // { href: '#', label: 'eNewlsetter Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewlsetter Subscription', target: '_blank' },
         { href: '/page/contact-us', label: 'Contact Us' },
         { href: 'https://designmanufacturing.informa.com/new-equipment-digest/', label: 'Advertise' },
         { href: 'https://www.endeavorbusinessmedia.com/privacy-policy', label: 'Privacy & Cookie Policy', target: '_blank' },

--- a/sites/newequipment.com/config/site.js
+++ b/sites/newequipment.com/config/site.js
@@ -1,8 +1,10 @@
 const navigation = require('./navigation');
+const dragonForms = require('./dragon-forms');
 
 module.exports = {
   company: 'Endeavor Business Media, LLC',
   navigation,
+  dragonForms,
   homePageSections: [
     { alias: 'plant-operations', name: 'Plant Operatinos' },
     { alias: 'research-and-development', name: 'Research and Development' },
@@ -36,5 +38,5 @@ module.exports = {
   wufoo: {
     userName: 'cygnuscorporate',
   },
-  newsletterSubscribeLink: 'https://mfg.informabi.com/LP=1531',
+  newsletterSubscribeLink: dragonForms.getFormUrl('newsletterSignup'),
 };

--- a/sites/powerelectronics.com/config/dragon-forms.js
+++ b/sites/powerelectronics.com/config/dragon-forms.js
@@ -1,0 +1,9 @@
+const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
+
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+
+// config
+//   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })
+//   .addForm('magazineSignup', { omedasite: 'PEN6133_ASland' });
+
+module.exports = config;

--- a/sites/powerelectronics.com/config/dragon-forms.js
+++ b/sites/powerelectronics.com/config/dragon-forms.js
@@ -1,6 +1,6 @@
 const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
 
-const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com' });
 
 // config
 //   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })

--- a/sites/powerelectronics.com/config/navigation.js
+++ b/sites/powerelectronics.com/config/navigation.js
@@ -1,3 +1,5 @@
+const dragonForms = require('./dragon-forms');
+
 module.exports = {
   tertiary: {
     items: [
@@ -29,8 +31,8 @@ module.exports = {
       items: [
         { href: '/webinars', label: 'Webinars' },
         { href: '/white-papers', label: 'White Papers' },
-        // { href: '#', label: 'Magazine Subscription', target: '_blank' },
-        // { href: '#', label: 'eNewlsetter Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewlsetter Subscription', target: '_blank' },
         { href: '/page/contact-us', label: 'Contact Us' },
         { href: 'https://designengineering.informa.com/power-electronics/', label: 'Advertise' },
         { href: 'https://www.endeavorbusinessmedia.com/privacy-policy', label: 'Privacy & Cookie Policy', target: '_blank' },

--- a/sites/powerelectronics.com/config/site.js
+++ b/sites/powerelectronics.com/config/site.js
@@ -1,8 +1,10 @@
 const navigation = require('./navigation');
+const dragonForms = require('./dragon-forms');
 
 module.exports = {
   company: 'Endeavor Business Media, LLC',
   navigation,
+  dragonForms,
   homePageSections: [
     { alias: 'power-management', name: 'Power Management' },
     { alias: 'alternative-energy', name: 'Alternative Energy' },
@@ -36,5 +38,5 @@ module.exports = {
   wufoo: {
     userName: 'cygnuscorporate',
   },
-  newsletterSubscribeLink: 'https://design.informabi.com/LP=3220',
+  newsletterSubscribeLink: dragonForms.getFormUrl('newsletterSignup'),
 };

--- a/sites/refrigeratedtransporter.com/config/dragon-forms.js
+++ b/sites/refrigeratedtransporter.com/config/dragon-forms.js
@@ -1,0 +1,9 @@
+const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
+
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+
+// config
+//   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })
+//   .addForm('magazineSignup', { omedasite: 'PEN6133_ASland' });
+
+module.exports = config;

--- a/sites/refrigeratedtransporter.com/config/dragon-forms.js
+++ b/sites/refrigeratedtransporter.com/config/dragon-forms.js
@@ -1,6 +1,6 @@
 const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
 
-const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com' });
 
 // config
 //   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })

--- a/sites/refrigeratedtransporter.com/config/navigation.js
+++ b/sites/refrigeratedtransporter.com/config/navigation.js
@@ -1,3 +1,5 @@
+const dragonForms = require('./dragon-forms');
+
 module.exports = {
   tertiary: {
     items: [
@@ -33,8 +35,8 @@ module.exports = {
       items: [
         { href: '/webinars', label: 'Webinars' },
         { href: '/white-papers', label: 'White Papers' },
-        // { href: '#', label: 'Magazine Subscription', target: '_blank' },
-        // { href: '#', label: 'eNewlsetter Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewlsetter Subscription', target: '_blank' },
         { href: '/page/contact-us', label: 'Contact Us' },
         { href: 'https://cv.informa.com/refrigerated-transporter-2/', label: 'Advertise' },
         { href: 'https://www.endeavorbusinessmedia.com/privacy-policy', label: 'Privacy & Cookie Policy', target: '_blank' },

--- a/sites/refrigeratedtransporter.com/config/site.js
+++ b/sites/refrigeratedtransporter.com/config/site.js
@@ -1,8 +1,10 @@
 const navigation = require('./navigation');
+const dragonForms = require('./dragon-forms');
 
 module.exports = {
   company: 'Endeavor Business Media, LLC',
   navigation,
+  dragonForms,
   homePageSections: [
     { alias: 'carriers', name: 'Carriers' },
     { alias: 'foodservice', name: 'Food Service' },
@@ -36,5 +38,5 @@ module.exports = {
   wufoo: {
     userName: 'cygnuscorporate',
   },
-  newsletterSubscribeLink: 'https://tr.informabi.com/LP=1296',
+  newsletterSubscribeLink: dragonForms.getFormUrl('newsletterSignup'),
 };

--- a/sites/rermag.com/config/dragon-forms.js
+++ b/sites/rermag.com/config/dragon-forms.js
@@ -1,6 +1,6 @@
 const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
 
-const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com' });
 
 config
   .addOmedaSite('newsletterSignup', { omedasite: 'RERnewpref' })

--- a/sites/rermag.com/config/dragon-forms.js
+++ b/sites/rermag.com/config/dragon-forms.js
@@ -1,0 +1,9 @@
+const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
+
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+
+config
+  .addOmedaSite('newsletterSignup', { omedasite: 'RERnewpref' })
+  .addOmedaSite('magazineSignup', { omedasite: 'PEN6139_RQnew', query: { pk: 'RQnew' } });
+
+module.exports = config;

--- a/sites/rermag.com/config/navigation.js
+++ b/sites/rermag.com/config/navigation.js
@@ -1,3 +1,5 @@
+const dragonForms = require('./dragon-forms');
+
 module.exports = {
   tertiary: {
     items: [
@@ -32,11 +34,11 @@ module.exports = {
       modifiers: ['secondary'],
       items: [
         { href: '/webinar', label: 'Webinars' },
-        { href: 'https://endeavor.dragonforms.com/loading.do?omedasite=RERnewpref', label: 'Newsletters', target: '_blank' },
+        { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewlsetter Subscription', target: '_blank' },
         { href: '/page/contact-us', label: 'Contact Us' },
         { href: 'https://buildings.informa.com/rental-equipment-register/', label: 'Advertise', target: '_blank' },
         { href: '/classifieds', label: 'Jobs' },
-        { href: 'https://informa.dragonforms.com/loading.do?omedasite=PEN6139_RQnew&pk=RQnew', label: 'Subscribe', target: '_blank' },
+        { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
         { href: 'http://directory.rermag.com/Main/DirectoryHome.aspx', label: 'Buyers Guide', target: '_blank' },
         { href: '/associations', label: 'Associations' },
         { href: 'https://www.argifocus.com/client/RentalEquipmentRegister/LM1/lm/rsdefault.asp', label: 'Free Product Info', target: '_blank' },

--- a/sites/rermag.com/config/site.js
+++ b/sites/rermag.com/config/site.js
@@ -1,8 +1,10 @@
 const navigation = require('./navigation');
+const dragonForms = require('./dragon-forms');
 
 module.exports = {
   company: 'Endeavor Business Media, LLC',
   navigation,
+  dragonForms,
   homePageSections: [
     { alias: 'business-technology', name: 'Business & Technology' },
     { alias: 'mergers-acquisitions', name: 'Mergers & Acquisitions' },
@@ -36,5 +38,5 @@ module.exports = {
   wufoo: {
     userName: 'cygnuscorporate',
   },
-  newsletterSubscribeLink: 'https://endeavor.dragonforms.com/loading.do?omedasite=RERnewpref',
+  newsletterSubscribeLink: dragonForms.getFormUrl('newsletterSignup'),
 };

--- a/sites/sourcetoday.com/config/dragon-forms.js
+++ b/sites/sourcetoday.com/config/dragon-forms.js
@@ -1,0 +1,9 @@
+const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
+
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+
+// config
+//   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })
+//   .addForm('magazineSignup', { omedasite: 'PEN6133_ASland' });
+
+module.exports = config;

--- a/sites/sourcetoday.com/config/dragon-forms.js
+++ b/sites/sourcetoday.com/config/dragon-forms.js
@@ -1,6 +1,6 @@
 const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
 
-const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com' });
 
 // config
 //   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })

--- a/sites/sourcetoday.com/config/navigation.js
+++ b/sites/sourcetoday.com/config/navigation.js
@@ -1,3 +1,5 @@
+const dragonForms = require('./dragon-forms');
+
 module.exports = {
   tertiary: {
     items: [
@@ -33,8 +35,8 @@ module.exports = {
       items: [
         { href: '/webinars', label: 'Webinars' },
         { href: '/white-papers', label: 'White Papers' },
-        // { href: '#', label: 'Magazine Subscription', target: '_blank' },
-        // { href: '#', label: 'eNewlsetter Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewlsetter Subscription', target: '_blank' },
         { href: '/page/contact-us', label: 'Contact Us' },
         { href: 'https://designengineering.informa.com/source-today/', label: 'Advertise' },
         { href: 'https://www.endeavorbusinessmedia.com/privacy-policy', label: 'Privacy & Cookie Policy', target: '_blank' },

--- a/sites/sourcetoday.com/config/site.js
+++ b/sites/sourcetoday.com/config/site.js
@@ -1,8 +1,10 @@
 const navigation = require('./navigation');
+const dragonForms = require('./dragon-forms');
 
 module.exports = {
   company: 'Endeavor Business Media, LLC',
   navigation,
+  dragonForms,
   homePageSections: [
     { alias: 'supply-chain', name: 'Supply Chain' },
     { alias: 'news', name: 'News' },
@@ -35,5 +37,5 @@ module.exports = {
   wufoo: {
     userName: 'cygnuscorporate',
   },
-  newsletterSubscribeLink: 'https://design.informabi.com/LP=3741',
+  newsletterSubscribeLink: dragonForms.getFormUrl('newsletterSignup'),
 };

--- a/sites/tdworld.com/config/dragon-forms.js
+++ b/sites/tdworld.com/config/dragon-forms.js
@@ -1,0 +1,9 @@
+const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
+
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+
+config
+  .addOmedaSite('newsletterSignup', { omedasite: 'TWnewpref' })
+  .addOmedaSite('magazineSignup', { omedasite: 'PEN6138_TWland', query: { pk: 'NN71RA' } });
+
+module.exports = config;

--- a/sites/tdworld.com/config/dragon-forms.js
+++ b/sites/tdworld.com/config/dragon-forms.js
@@ -1,6 +1,6 @@
 const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
 
-const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com' });
 
 config
   .addOmedaSite('newsletterSignup', { omedasite: 'TWnewpref' })

--- a/sites/tdworld.com/config/navigation.js
+++ b/sites/tdworld.com/config/navigation.js
@@ -1,3 +1,5 @@
+const dragonForms = require('./dragon-forms');
+
 module.exports = {
   tertiary: {
     items: [
@@ -50,8 +52,8 @@ module.exports = {
         { href: '/td-world-media-partners', label: 'Media Partners' },
         { href: '/page/about-us', label: 'About Us' },
         { href: 'https://power.informa.com/', label: 'Advertise', target: '_blank' },
-        { href: 'https://endeavor.dragonforms.com/loading.do?omedasite=TWnewpref', label: 'Newsletters', target: '_blank' },
-        { href: 'https://informa.dragonforms.com/PEN6138_TWland&PK=NN71RA', label: 'Subscribe', target: '_blank' },
+        { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewlsetter Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
         { href: 'https://www.endeavorbusinessmedia.com/privacy-policy', label: 'Privacy & Cookie Policy', target: '_blank' },
         { href: 'https://www.endeavorbusinessmedia.com/endeavor-terms', label: 'Terms of Service', target: '_blank' },
         { href: 'http://www.penton.com/privacy-policy#ThirdPartyAdvertisingTech', label: 'Ad Choices', target: '_blank' },

--- a/sites/tdworld.com/config/site.js
+++ b/sites/tdworld.com/config/site.js
@@ -1,8 +1,10 @@
 const navigation = require('./navigation');
+const dragonForms = require('./dragon-forms');
 
 module.exports = {
   company: 'Endeavor Business Media, LLC',
   navigation,
+  dragonForms,
   homePageSections: [
     { alias: 'distributed-energy-resources', name: 'Distributed Energy Resources' },
     { alias: 'electric-utility-operations', name: 'Electric Utility Operations' },
@@ -38,5 +40,5 @@ module.exports = {
   wufoo: {
     userName: 'cygnuscorporate',
   },
-  newsletterSubscribeLink: 'https://endeavor.dragonforms.com/loading.do?omedasite=TWnewpref',
+  newsletterSubscribeLink: dragonForms.getFormUrl('newsletterSignup'),
 };

--- a/sites/trailer-bodybuilders.com/config/dragon-forms.js
+++ b/sites/trailer-bodybuilders.com/config/dragon-forms.js
@@ -1,0 +1,9 @@
+const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
+
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+
+// config
+//   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })
+//   .addForm('magazineSignup', { omedasite: 'PEN6133_ASland' });
+
+module.exports = config;

--- a/sites/trailer-bodybuilders.com/config/dragon-forms.js
+++ b/sites/trailer-bodybuilders.com/config/dragon-forms.js
@@ -1,6 +1,6 @@
 const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
 
-const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com' });
 
 // config
 //   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })

--- a/sites/trailer-bodybuilders.com/config/navigation.js
+++ b/sites/trailer-bodybuilders.com/config/navigation.js
@@ -1,3 +1,5 @@
+const dragonForms = require('./dragon-forms');
+
 module.exports = {
   tertiary: {
     items: [
@@ -34,8 +36,8 @@ module.exports = {
       items: [
         { href: '/webinars', label: 'Webinars' },
         { href: '/white-papers', label: 'White Papers' },
-        // { href: '#', label: 'Magazine Subscription', target: '_blank' },
-        // { href: '#', label: 'eNewlsetter Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewlsetter Subscription', target: '_blank' },
         { href: '/page/contact-us', label: 'Contact Us' },
         { href: 'https://cv.informa.com/trailer-body-builders/', label: 'Advertise' },
         { href: 'https://www.endeavorbusinessmedia.com/privacy-policy', label: 'Privacy & Cookie Policy', target: '_blank' },

--- a/sites/trailer-bodybuilders.com/config/site.js
+++ b/sites/trailer-bodybuilders.com/config/site.js
@@ -1,8 +1,10 @@
 const navigation = require('./navigation');
+const dragonForms = require('./dragon-forms');
 
 module.exports = {
   company: 'Endeavor Business Media, LLC',
   navigation,
+  dragonForms,
   homePageSections: [
     { alias: 'trailers', name: 'Trailers' },
     { alias: 'truck-bodies', name: 'Truck Bodies' },
@@ -36,5 +38,5 @@ module.exports = {
   wufoo: {
     userName: 'cygnuscorporate',
   },
-  newsletterSubscribeLink: 'https://s434533438.t.eloqua.com/e/f2',
+  newsletterSubscribeLink: dragonForms.getFormUrl('newsletterSignup'),
 };

--- a/sites/trucker.com/config/dragon-forms.js
+++ b/sites/trucker.com/config/dragon-forms.js
@@ -1,0 +1,9 @@
+const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
+
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+
+// config
+//   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })
+//   .addForm('magazineSignup', { omedasite: 'PEN6133_ASland' });
+
+module.exports = config;

--- a/sites/trucker.com/config/dragon-forms.js
+++ b/sites/trucker.com/config/dragon-forms.js
@@ -1,6 +1,6 @@
 const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
 
-const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com' });
 
 // config
 //   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })

--- a/sites/trucker.com/config/navigation.js
+++ b/sites/trucker.com/config/navigation.js
@@ -1,3 +1,5 @@
+const dragonForms = require('./dragon-forms');
+
 module.exports = {
   tertiary: {
     items: [
@@ -34,8 +36,8 @@ module.exports = {
       items: [
         { href: '/webinars', label: 'Webinars' },
         { href: '/white-papers', label: 'White Papers' },
-        // { href: '#', label: 'Magazine Subscription', target: '_blank' },
-        // { href: '#', label: 'eNewlsetter Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewlsetter Subscription', target: '_blank' },
         { href: '/page/contact-us', label: 'Contact Us' },
         { href: 'https://cv.informa.com/american-trucker/', label: 'Advertise' },
         { href: 'https://www.endeavorbusinessmedia.com/privacy-policy', label: 'Privacy & Cookie Policy', target: '_blank' },

--- a/sites/trucker.com/config/site.js
+++ b/sites/trucker.com/config/site.js
@@ -1,8 +1,10 @@
 const navigation = require('./navigation');
+const dragonForms = require('./dragon-forms');
 
 module.exports = {
   company: 'Endeavor Business Media, LLC',
   navigation,
+  dragonForms,
   homePageSections: [
     { alias: 'equipment', name: 'Equipment' },
     { alias: 'drivers', name: 'Drivers' },
@@ -36,5 +38,5 @@ module.exports = {
   wufoo: {
     userName: 'cygnuscorporate',
   },
-  newsletterSubscribeLink: 'https://tr.informabi.com/LP=1385',
+  newsletterSubscribeLink: dragonForms.getFormUrl('newsletterSignup'),
 };

--- a/sites/truckfleetmro.com/config/dragon-forms.js
+++ b/sites/truckfleetmro.com/config/dragon-forms.js
@@ -1,0 +1,9 @@
+const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
+
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+
+// config
+//   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })
+//   .addForm('magazineSignup', { omedasite: 'PEN6133_ASland' });
+
+module.exports = config;

--- a/sites/truckfleetmro.com/config/dragon-forms.js
+++ b/sites/truckfleetmro.com/config/dragon-forms.js
@@ -1,6 +1,6 @@
 const DragonFormsConfig = require('@endeavor-business-media/lazarus-shared/config/dragon-forms');
 
-const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com/loading.do' });
+const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com' });
 
 // config
 //   .addForm('newsletterSignup', { omedasite: 'ASUnewpref' })

--- a/sites/truckfleetmro.com/config/navigation.js
+++ b/sites/truckfleetmro.com/config/navigation.js
@@ -1,3 +1,5 @@
+const dragonForms = require('./dragon-forms');
+
 module.exports = {
   tertiary: {
     items: [
@@ -33,8 +35,8 @@ module.exports = {
       items: [
         { href: '/webinars', label: 'Webinars' },
         { href: '/white-papers', label: 'White Papers' },
-        // { href: '#', label: 'Magazine Subscription', target: '_blank' },
-        // { href: '#', label: 'eNewlsetter Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
+        { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewlsetter Subscription', target: '_blank' },
         { href: '/page/contact-us', label: 'Contact Us' },
         { href: 'https://cv.informa.com/fleet-owner/', label: 'Advertise' },
         { href: 'https://www.endeavorbusinessmedia.com/privacy-policy', label: 'Privacy & Cookie Policy', target: '_blank' },

--- a/sites/truckfleetmro.com/config/site.js
+++ b/sites/truckfleetmro.com/config/site.js
@@ -1,8 +1,10 @@
 const navigation = require('./navigation');
+const dragonForms = require('./dragon-forms');
 
 module.exports = {
   company: 'Endeavor Business Media, LLC',
   navigation,
+  dragonForms,
   homePageSections: [
     { alias: 'shop-management', name: 'Shop Management' },
     { alias: 'technology', name: 'Technology' },
@@ -34,5 +36,5 @@ module.exports = {
   wufoo: {
     userName: 'cygnuscorporate',
   },
-  newsletterSubscribeLink: 'https://tr.informabi.com/LP=1397',
+  newsletterSubscribeLink: dragonForms.getFormUrl('newsletterSignup'),
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -850,10 +850,10 @@
   resolved "https://registry.yarnpkg.com/@base-cms/marko-web-icons/-/marko-web-icons-1.0.0.tgz#ff0270d64c679a5f7fcc8c33af91a59435aaec56"
   integrity sha512-KJ8bioDhhyTzZDmm+NQnjfO3xVRSXc6Q70PP2+KrT2JyrQuaforvfZxSDLASRb7txX0w+t3I624HUqoi6XvWoQ==
 
-"@base-cms/marko-web-theme-default@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@base-cms/marko-web-theme-default/-/marko-web-theme-default-1.0.1.tgz#c6a22b4d828980e54f0f55bd4e4501b7022ad908"
-  integrity sha512-8SQzKRYbkiegE2bcIWr4KWsOz/RmiucK9CrpCldAT1IyyZg5Q13ktP+0OPmuiMxzW4HPrrgAY8NRBJcGJS2ezA==
+"@base-cms/marko-web-theme-default@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@base-cms/marko-web-theme-default/-/marko-web-theme-default-1.1.0.tgz#9348ccf9e21d269f5bed02b624cb20343f5be517"
+  integrity sha512-blGEndWPwXnVVNfod+8ZfcShhHnBTFL1rN+CfrN0BRgpV2w4z9o/R7g7ODOXO/7cj6CgQPxgiMrln+6ITSGjPA==
   dependencies:
     "@base-cms/marko-web-icons" "^1.0.0"
     "@base-cms/object-path" "^1.0.0"


### PR DESCRIPTION
- add newsletter block to home, website section, and content pages
- on form submit, directs user to Dragon Form with email address pre-populated
- will only display if a `newsletterSignup` form is configured in the `DragonFormsConfig`
- magazine and newsletter links now use the `DragonFormsConfig`

![image](https://user-images.githubusercontent.com/3289485/70542444-582cd480-1b2e-11ea-9a6e-cc280aba758c.png)
