### PR TITLE
Support for full-width content pages

### DIFF
--- a/packages/informa-gam/utils/can-load-prestitial.js
+++ b/packages/informa-gam/utils/can-load-prestitial.js
@@ -1,3 +1,11 @@
 const { get } = require('@base-cms/object-path');
 
-module.exports = page => ['content', 'website-section'].includes(get(page, 'for', false));
+module.exports = (page) => {
+  const pageFor = get(page, 'for', false);
+  const type = get(page, 'type');
+  if (pageFor === 'content') {
+    if (type === 'whitepaper') return false;
+    return true;
+  }
+  return pageFor === 'website-section';
+};

--- a/packages/lazarus-shared/components/elements/content-body.marko
+++ b/packages/lazarus-shared/components/elements/content-body.marko
@@ -7,19 +7,23 @@ $ const { site } = out.global;
 $ const { node: content } = input;
 $ const { type } = content;
 
+$ const adsEnabled = defaultValue(input.adsEnabled, true);
 $ const isPreview = defaultValue(input.isPreview, false);
 $ const body = isPreview ? getContentPreview({ body: content.body, selector: "p:nth-of-type(1)" }) : content.body;
 $ const bodyId = `content-body-${content.id}`;
 
 <default-theme-page-contents|{ blockName }|>
   <default-theme-content-contact-details obj=content />
-  <informa-gam-adunit
-    location=adLocation(type)
-    position="inarticle1"
-    modifiers=["max-width-300", "float-right"]
-  >
-    <@context content-id=content.id />
-  </informa-gam-adunit>
+
+  <if(adsEnabled)>
+    <informa-gam-adunit
+      location=adLocation(type)
+      position="inarticle1"
+      modifiers=["max-width-300", "float-right"]
+    >
+      <@context content-id=content.id />
+    </informa-gam-adunit>
+  </if>
 
   <!-- Note: the `itemprop` attr must be set for Teads to properly select the body -->
   <marko-web-content-body block-name=blockName obj={ body } attrs={ id: bodyId, itemprop: "articleBody" } />
@@ -34,55 +38,59 @@ $ const bodyId = `content-body-${content.id}`;
     <!-- Load "embedded" Eloqua iframes -->
     <lazarus-load-eloqua-iframes body-id=bodyId />
 
-    <!-- Teads ads does its own injection. -->
-    <informa-gam-adunit
-      location=adLocation(type)
-      position="inarticlevid"
-    >
-      <@context content-id=content.id />
-    </informa-gam-adunit>
+    <if(adsEnabled)>
+      <!-- Teads ads does its own injection. -->
+      <informa-gam-adunit
+        location=adLocation(type)
+        position="inarticlevid"
+      >
+        <@context content-id=content.id />
+      </informa-gam-adunit>
 
-    <!-- inject native ad after second paragraph -->
-    <informa-gam-direct-inject-adunit selector=`#${bodyId} > p:nth-of-type(2)`>
-      <@adunit location=adLocation(type) position="native_inline" modifiers=["body-inline"]>
-        <@context content-id=content.id />
-      </@adunit>
-    </informa-gam-direct-inject-adunit>
 
-    <informa-gam-inject-adunits selector=`#${bodyId}`>
-      <!-- @todo find a content item that is using the reveal position -->
-      <@inject
-        at=1200
-        location=adLocation(type)
-        position="reveal"
-      >
-        <@context content-id=content.id />
-      </@inject>
-      <@inject
-        at=2500
-        location=adLocation(type)
-        position="inarticle2"
-        modifiers=["max-width-300", "float-right"]
-      >
-        <@context content-id=content.id />
-      </@inject>
-      <@inject
-        at=3500
-        location=adLocation(type)
-        position="inarticle3"
-        modifiers=["max-width-300", "float-right"]
-      >
-        <@context content-id=content.id />
-      </@inject>
-      <@inject
-        at=6000
-        location=adLocation(type)
-        position="inarticle4"
-        modifiers=["max-width-300", "float-right"]
-      >
-        <@context content-id=content.id />
-      </@inject>
-    </informa-gam-inject-adunits>
+      <!-- inject native ad after second paragraph -->
+      <informa-gam-direct-inject-adunit selector=`#${bodyId} > p:nth-of-type(2)`>
+        <@adunit location=adLocation(type) position="native_inline" modifiers=["body-inline"]>
+          <@context content-id=content.id />
+        </@adunit>
+      </informa-gam-direct-inject-adunit>
+
+      <informa-gam-inject-adunits selector=`#${bodyId}`>
+        <!-- @todo find a content item that is using the reveal position -->
+        <@inject
+          at=1200
+          location=adLocation(type)
+          position="reveal"
+        >
+          <@context content-id=content.id />
+        </@inject>
+        <@inject
+          at=2500
+          location=adLocation(type)
+          position="inarticle2"
+          modifiers=["max-width-300", "float-right"]
+        >
+          <@context content-id=content.id />
+        </@inject>
+        <@inject
+          at=3500
+          location=adLocation(type)
+          position="inarticle3"
+          modifiers=["max-width-300", "float-right"]
+        >
+          <@context content-id=content.id />
+        </@inject>
+        <@inject
+          at=6000
+          location=adLocation(type)
+          position="inarticle4"
+          modifiers=["max-width-300", "float-right"]
+        >
+          <@context content-id=content.id />
+        </@inject>
+      </informa-gam-inject-adunits>
+    </if>
+
     <marko-web-content-sidebars block-name=blockName obj=content />
 
     <if(type === "document")>

--- a/packages/lazarus-shared/components/elements/marko.json
+++ b/packages/lazarus-shared/components/elements/marko.json
@@ -2,7 +2,8 @@
   "<lazarus-shared-content-body-element>": {
     "template": "./content-body.marko",
     "@node": "object",
-    "@is-preview": "boolean"
+    "@is-preview": "boolean",
+    "@ads-enabled": "boolean"
   },
   "<lazarus-shared-slideshow-button-element>": {
     "template": "./slideshow-button.marko",

--- a/packages/lazarus-shared/components/nodes/content-page-card.marko
+++ b/packages/lazarus-shared/components/nodes/content-page-card.marko
@@ -1,5 +1,7 @@
 import { getAsObject, getAsArray, get } from "@base-cms/object-path";
 import { buildImgixUrl } from "@base-cms/image";
+import defaultValue from "@base-cms/marko-core/utils/default-value";
+import imageHeight from "@base-cms/marko-web/components/node/utils/image-height";
 
 $ const blockName = "content-page-card";
 
@@ -11,7 +13,12 @@ $ const isSponsored = getAsArray(content, "labels").includes("Sponsored");
 $ const { type } = content;
 
 $ const hasImage = Boolean(primaryImage.src);
-$ const src = buildImgixUrl(primaryImage.src, { w: 768, h: 432, fit: "crop" });
+$ const imgInput = getAsObject(input, "image");
+$ const imgWidth = defaultValue(imgInput.width, 768);
+$ const imgAspect = defaultValue(imgInput.ar, "16:9");
+$ const imgHeight = imageHeight(imgWidth, imgAspect);
+
+$ const src = buildImgixUrl(primaryImage.src, { w: imgWidth, h: imgHeight, fit: "crop" });
 $ const srcset = [`${buildImgixUrl(src, { dpr: 2 })} 2x`];
 
 $ const hasEmbedCode = Boolean(content.embedCode);
@@ -30,7 +37,11 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
   <marko-web-node-element name="header" block-name=blockName>
     <if(displayPrimaryImage)>
       <marko-web-node-element name="header-image-wrapper" block-name=blockName>
-        <marko-web-node-element name="image-inner-wrapper" block-name=blockName>
+        <marko-web-node-element
+          name="image-inner-wrapper"
+          block-name=blockName
+          modifiers=[imgAspect.replace(":", "by")]
+        >
           <marko-web-img
             src=src
             srcset=srcset

--- a/packages/lazarus-shared/components/nodes/content-page.marko
+++ b/packages/lazarus-shared/components/nodes/content-page.marko
@@ -9,10 +9,17 @@ $ const requiresRegistration = get(content, "userRegistration.isRequired");
 
 $ const fullWidth = defaultValue(input.fullWidth, false);
 $ const modifiers = [];
-$ if (fullWidth) modifiers.push("full-width");
+$ const imgInput = {};
+$ if (fullWidth) {
+  modifiers.push("full-width");
+  imgInput.ar = "21:9";
+  imgInput.width = 1200;
+};
 
 <marko-web-block name=blockName modifiers=modifiers>
-  <lazarus-shared-content-page-card content=content modifiers=modifiers />
+  <lazarus-shared-content-page-card content=content modifiers=modifiers>
+    <@image ...imgInput />
+  </lazarus-shared-content-page-card>
   <marko-web-element name="contents" block-name=blockName>
     <marko-web-social-sharing
       path=content.siteContext.path

--- a/packages/lazarus-shared/components/nodes/content-page.marko
+++ b/packages/lazarus-shared/components/nodes/content-page.marko
@@ -1,12 +1,18 @@
 import { getAsObject, get } from "@base-cms/object-path";
+import defaultValue from "@base-cms/marko-core/utils/default-value";
 
 $ const { node: content } = input;
-$ const primarySection = getAsObject(content, "primarySection");
-$ const requiresRegistration = get(content, "userRegistration.isRequired");
 $ const blockName = "content-page-node";
 
-<marko-web-block name=blockName>
-  <lazarus-shared-content-page-card content=content />
+$ const primarySection = getAsObject(content, "primarySection");
+$ const requiresRegistration = get(content, "userRegistration.isRequired");
+
+$ const fullWidth = defaultValue(input.fullWidth, false);
+$ const modifiers = [];
+$ if (fullWidth) modifiers.push("full-width");
+
+<marko-web-block name=blockName modifiers=modifiers>
+  <lazarus-shared-content-page-card content=content modifiers=modifiers />
   <marko-web-element name="contents" block-name=blockName>
     <marko-web-social-sharing
       path=content.siteContext.path

--- a/packages/lazarus-shared/components/nodes/content-page.marko
+++ b/packages/lazarus-shared/components/nodes/content-page.marko
@@ -3,40 +3,42 @@ import { getAsObject, get } from "@base-cms/object-path";
 $ const { node: content } = input;
 $ const primarySection = getAsObject(content, "primarySection");
 $ const requiresRegistration = get(content, "userRegistration.isRequired");
+$ const blockName = "content-page-node";
 
-<lazarus-skin-page-grid-col modifiers=["content-page"]>
+<marko-web-block name=blockName>
   <lazarus-shared-content-page-card content=content />
+  <marko-web-element name="contents" block-name=blockName>
+    <marko-web-social-sharing
+      path=content.siteContext.path
+      providers=["email", "facebook", "linkedin", "twitter", "pinterest"]
+    />
+    <marko-web-identity-x-access|context| enabled=requiresRegistration>
+      <if(!context.canAccess)>
+        <lazarus-shared-content-body-element
+          node=content
+          is-preview=true
+          ads-enabled=input.adsEnabled
+        />
+        <lazarus-shared-content-gate
+          is-logged-in=context.isLoggedIn
+          has-required-access-level=context.hasRequiredAccessLevel
+          requires-access-level=context.hasRequiredAccessLevel
+          messages=context.messages
+        />
+      </if>
+      <else>
+        <lazarus-shared-content-body-element
+          node=content
+          ads-enabled=input.adsEnabled
+        />
+      </else>
+    </marko-web-identity-x-access>
 
-  <marko-web-social-sharing
-    path=content.siteContext.path
-    providers=["email", "facebook", "linkedin", "twitter", "pinterest"]
-  />
-  <marko-web-identity-x-access|context| enabled=requiresRegistration>
-    <if(!context.canAccess)>
-      <lazarus-shared-content-body-element
-        node=content
-        is-preview=true
-        ads-enabled=input.adsEnabled
-      />
-      <lazarus-shared-content-gate
-        is-logged-in=context.isLoggedIn
-        has-required-access-level=context.hasRequiredAccessLevel
-        requires-access-level=context.hasRequiredAccessLevel
-        messages=context.messages
-      />
-    </if>
-    <else>
-      <lazarus-shared-content-body-element
-        node=content
-        ads-enabled=input.adsEnabled
-      />
-    </else>
-  </marko-web-identity-x-access>
-
-  <lazarus-shared-related-content-block
-    id=content.id
-    type=content.type
-    section-id=primarySection.id
-    section-name=primarySection.name
-  />
-</lazarus-skin-page-grid-col>
+    <lazarus-shared-related-content-block
+      id=content.id
+      type=content.type
+      section-id=primarySection.id
+      section-name=primarySection.name
+    />
+  </marko-web-element>
+</marko-web-block>

--- a/packages/lazarus-shared/components/nodes/content-page.marko
+++ b/packages/lazarus-shared/components/nodes/content-page.marko
@@ -11,10 +11,13 @@ $ const requiresRegistration = get(content, "userRegistration.isRequired");
     path=content.siteContext.path
     providers=["email", "facebook", "linkedin", "twitter", "pinterest"]
   />
-
   <marko-web-identity-x-access|context| enabled=requiresRegistration>
     <if(!context.canAccess)>
-      <lazarus-shared-content-body-element node=content is-preview=true />
+      <lazarus-shared-content-body-element
+        node=content
+        is-preview=true
+        ads-enabled=input.adsEnabled
+      />
       <lazarus-shared-content-gate
         is-logged-in=context.isLoggedIn
         has-required-access-level=context.hasRequiredAccessLevel
@@ -23,7 +26,10 @@ $ const requiresRegistration = get(content, "userRegistration.isRequired");
       />
     </if>
     <else>
-      <lazarus-shared-content-body-element node=content />
+      <lazarus-shared-content-body-element
+        node=content
+        ads-enabled=input.adsEnabled
+      />
     </else>
   </marko-web-identity-x-access>
 

--- a/packages/lazarus-shared/components/nodes/marko.json
+++ b/packages/lazarus-shared/components/nodes/marko.json
@@ -36,7 +36,8 @@
   "<lazarus-shared-content-page-node>": {
     "template": "./content-page.marko",
     "@node": "object",
-    "@ads-enabled": "boolean"
+    "@ads-enabled": "boolean",
+    "@full-width": "boolean"
   },
   "<lazarus-shared-contact-us-list-node>": {
     "template": "./contact-us-list.marko",

--- a/packages/lazarus-shared/components/nodes/marko.json
+++ b/packages/lazarus-shared/components/nodes/marko.json
@@ -45,6 +45,10 @@
   },
   "<lazarus-shared-content-page-card>": {
     "template": "./content-page-card.marko",
+    "<image>": {
+      "@width": "number",
+      "@ar": "string"
+    },
     "@content": "object",
     "@tag": "string",
     "@class": "string",

--- a/packages/lazarus-shared/components/nodes/marko.json
+++ b/packages/lazarus-shared/components/nodes/marko.json
@@ -35,7 +35,8 @@
   },
   "<lazarus-shared-content-page-node>": {
     "template": "./content-page.marko",
-    "@node": "object"
+    "@node": "object",
+    "@ads-enabled": "boolean"
   },
   "<lazarus-shared-contact-us-list-node>": {
     "template": "./contact-us-list.marko",

--- a/packages/lazarus-shared/routes/content.js
+++ b/packages/lazarus-shared/routes/content.js
@@ -1,15 +1,22 @@
 const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 const slideshow = require('../templates/content/slideshow');
+const whitepaper = require('../templates/content/whitepaper');
 const queryFragment = require('../graphql/fragments/content-page');
 const slideshowFragment = require('../graphql/fragments/content-slideshow-page');
 
 module.exports = (app) => {
+  app.get('/*?whitepaper/:id(\\d{8})*', withContent({
+    template: whitepaper,
+    queryFragment,
+  }));
+
   app.get('/*?media-gallery/:id(\\d{8})/:slug/slideshow', withContent({
     template: slideshow,
     queryFragment: slideshowFragment,
     redirectOnPathMismatch: false,
   }));
+
   app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,

--- a/packages/lazarus-shared/templates/content/whitepaper.marko
+++ b/packages/lazarus-shared/templates/content/whitepaper.marko
@@ -1,0 +1,21 @@
+$ const { site } = out.global;
+$ const { id, type, pageNode } = data;
+
+<marko-web-content-page-layout id=id type=type>
+  <@head>
+    <marko-web-gtm-content-context|{ context }| id=id>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-content-context>
+  </@head>
+  <@page>
+    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
+      $ const section = resolved.getAsObject("primarySection");
+
+      <marko-web-page-wrapper modifiers=["top-border"]>
+        <@section>
+          <h1>Whitepaper</h1>
+        </@section>
+      </marko-web-page-wrapper>
+    </marko-web-resolve-page>
+  </@page>
+</marko-web-content-page-layout>

--- a/packages/lazarus-shared/templates/content/whitepaper.marko
+++ b/packages/lazarus-shared/templates/content/whitepaper.marko
@@ -12,10 +12,12 @@ $ const { id, type, pageNode } = data;
       $ const section = resolved.getAsObject("primarySection");
 
       <marko-web-page-wrapper modifiers=["top-border"]>
+        <!-- @todo readable width should calculate to 780px -->
         <@section>
           <lazarus-shared-content-page-node
             node=content
             ads-enabled=false
+            full-width=true
           />
         </@section>
       </marko-web-page-wrapper>

--- a/packages/lazarus-shared/templates/content/whitepaper.marko
+++ b/packages/lazarus-shared/templates/content/whitepaper.marko
@@ -13,7 +13,10 @@ $ const { id, type, pageNode } = data;
 
       <marko-web-page-wrapper modifiers=["top-border"]>
         <@section>
-          <h1>Whitepaper</h1>
+          <lazarus-shared-content-page-node
+            node=content
+            ads-enabled=false
+          />
         </@section>
       </marko-web-page-wrapper>
     </marko-web-resolve-page>

--- a/packages/lazarus-shared/theme.scss
+++ b/packages/lazarus-shared/theme.scss
@@ -140,6 +140,18 @@ $theme-sponsored-content-color: #ee591d !default;
   }
 }
 
+.content-page-node {
+  @include make-col-ready();
+  @include make-col(12);
+  padding-top: $grid-gutter-width;
+  padding-right: 50px;
+  padding-left: 50px;
+  @include media-breakpoint-down($theme-responsive-text-breakpoint) {
+    padding-right: $marko-web-page-wrapper-padding * 2;
+    padding-left: $marko-web-page-wrapper-padding * 2;
+  }
+}
+
 .content-page-card {
   &__sponsored-content {
     @include sponsored-content-tag();

--- a/packages/lazarus-shared/theme.scss
+++ b/packages/lazarus-shared/theme.scss
@@ -44,6 +44,7 @@ $theme-site-header-z-index: 15000;
 @import "../../node_modules/@base-cms/marko-web-theme-default/skins/lazarus/skin.scss";
 
 $theme-sponsored-content-color: #ee591d !default;
+$theme-content-page-node-full-width: 780px !default;
 
 @mixin sponsored-content-tag() {
   $line-height: 1.35;
@@ -141,6 +142,7 @@ $theme-sponsored-content-color: #ee591d !default;
 }
 
 .content-page-node {
+  $self: &;
   @include make-col-ready();
   @include make-col(12);
   padding-top: $grid-gutter-width;
@@ -150,9 +152,28 @@ $theme-sponsored-content-color: #ee591d !default;
     padding-right: $marko-web-page-wrapper-padding * 2;
     padding-left: $marko-web-page-wrapper-padding * 2;
   }
+
+  &--full-width {
+    padding-top: 0;
+    padding-right: $marko-web-page-wrapper-padding;
+    padding-left: $marko-web-page-wrapper-padding;
+    @include media-breakpoint-down($theme-responsive-text-breakpoint) {
+      padding-right: $marko-web-page-wrapper-padding;
+      padding-left: $marko-web-page-wrapper-padding;
+    }
+
+    #{ $self } {
+      &__contents {
+        max-width: $theme-content-page-node-full-width;
+        margin-right: auto;
+        margin-left: auto;
+      }
+    }
+  }
 }
 
 .content-page-card {
+  $self: &;
   &__sponsored-content {
     @include sponsored-content-tag();
     margin-bottom: .75rem;
@@ -174,6 +195,30 @@ $theme-sponsored-content-color: #ee591d !default;
     &--media-gallery {
       padding-top: 0;
       padding-bottom: 0;
+    }
+  }
+
+  &__image-inner-wrapper {
+    &--21by9 {
+      @include marko-web-node-fluid-image(21, 9);
+    }
+  }
+
+  &--full-width {
+    $spacer-size: $marko-web-page-wrapper-padding * 2;
+    margin-right: -$spacer-size;
+    margin-left: -$spacer-size;
+
+    #{ $self } {
+      &__header-body {
+        width: 100%;
+        max-width: $theme-content-page-node-full-width + ($spacer-size * 2);
+        padding-top: $spacer-size;
+        padding-right: $spacer-size;
+        padding-left: $spacer-size;
+        margin-right: auto;
+        margin-left: auto;
+      }
     }
   }
 }

--- a/packages/lazarus-shared/theme.scss
+++ b/packages/lazarus-shared/theme.scss
@@ -531,3 +531,9 @@ $theme-sponsored-content-color: #ee591d !default;
     border: none;
   }
 }
+
+// allow embeds to display natural width no greater than 100%
+[data-embed-type] {
+  width: auto;
+  max-width: 100%;
+}


### PR DESCRIPTION
Can also, (optionally) have ads disabled.

Applied to whitepapers (with ads off).