### PR TITLE
newsletter spelling

### DIFF
--- a/packages/site-setup/template/config/navigation.js
+++ b/packages/site-setup/template/config/navigation.js
@@ -27,7 +27,7 @@ module.exports = {
         { href: '/webinars', label: 'Webinars' },
         { href: '/white-papers', label: 'White Papers' },
         { href: '<NOT SET>', label: 'Magazine Subscription', target: '_blank' },
-        { href: '<NOT SET>', label: 'eNewlsetter Subscription', target: '_blank' },
+        { href: '<NOT SET>', label: 'eNewsletter Subscription', target: '_blank' },
         { href: '/contact-us', label: 'Contact Us' },
         { href: '/advertise', label: 'Advertise' },
         { href: 'https://www.endeavorbusinessmedia.com/privacy-policy', label: 'Privacy Statement', target: '_blank' },


### PR DESCRIPTION
Newsletter spelling was already corrected for the sites, but the template still had the incorrect spelling.