### PR TITLE
Ensure additional special chars are replaced

### DIFF
--- a/services/gam/graphql/utils/clean-path-value.js
+++ b/services/gam/graphql/utils/clean-path-value.js
@@ -5,7 +5,7 @@ module.exports = (value) => {
   // Replace special characters (as defined by GAM).
   v = v.replace(/["'=!+#*~;^()[\]<>,.&]/g, '');
   // Replace additional special chars (as defined by Penton PHP code).
-  v = v.replace(/|\?“‘’”…{}/g, '');
+  v = v.replace(/[|?“‘’”…{}]/g, '');
   // Replace multiple underscores with one.
   v = v.replace(/_{2,}/g, '_');
   return v.toLowerCase();


### PR DESCRIPTION
The previous regex was not declaring the special chars as a list of replacement options. As such, these characters were not being replaced.