### PR TITLE
Replace arrow function with standard function

### DIFF
--- a/packages/informa-gam/components/components/prestitial-script.marko
+++ b/packages/informa-gam/components/components/prestitial-script.marko
@@ -16,7 +16,7 @@
       if (adblockOn) removeOpacity();
     }, 2000);
 
-    googletag.cmd.push(() => {
+    googletag.cmd.push(function() {
       googletag.pubads().addEventListener('slotRenderEnded', function(event) {
         adblockOn = 0;
         if (event.slot.getSlotElementId() === 'div-interstitial' && event.isEmpty) {


### PR DESCRIPTION
https://southcomm.atlassian.net/browse/CS-3951

=> is preventing opacity removal, which is in turn causing sites not to display on IE11

![Screen Shot 2020-01-14 at 3 20 46 PM](https://user-images.githubusercontent.com/6343242/72385062-4f5a9000-36e4-11ea-8faa-ea4ffa59a54b.png)

![Screen Shot 2020-01-14 at 3 39 06 PM](https://user-images.githubusercontent.com/6343242/72385061-4f5a9000-36e4-11ea-9274-8c7600b3b1d4.png)

There are also a number of styling display issues related to the use of flex box in IE11, which would need to be addressed in a different request.

![Screen Shot 2020-01-14 at 3 24 18 PM](https://user-images.githubusercontent.com/6343242/72385113-64cfba00-36e4-11ea-8db3-7d56b6818f9d.png)
