### PR TITLE
Create directory landing page with category tree navigation

### DIFF
--- a/packages/lazarus-shared/browser/directory-facets/facet.vue
+++ b/packages/lazarus-shared/browser/directory-facets/facet.vue
@@ -5,18 +5,18 @@
       :is-expanded="isExpanded"
       @click="toggleExpanded"
     />
-    <node-link :alias="alias" :name="name" />
+    <facet-link :alias="alias" :name="name" />
     <slot :has-children="hasChildren" :is-expanded="isExpanded" :alias="alias" />
   </div>
 </template>
 
 <script>
-import NodeLink from './link.vue';
+import FacetLink from './link.vue';
 import ToggleButton from './toggle-button.vue';
 
 export default {
   components: {
-    NodeLink,
+    FacetLink,
     ToggleButton,
   },
 
@@ -45,9 +45,9 @@ export default {
 
   computed: {
     classNames() {
-      const elementName = 'directory-facets__node';
-      const classNames = [elementName];
-      if (this.isActive) classNames.push(`${elementName}--active`);
+      const blockName = 'directory-facet';
+      const classNames = [blockName];
+      if (this.isActive) classNames.push(`${blockName}--active`);
       return classNames;
     },
     hasChildren() {

--- a/packages/lazarus-shared/browser/directory-facets/facet.vue
+++ b/packages/lazarus-shared/browser/directory-facets/facet.vue
@@ -1,11 +1,13 @@
 <template>
   <div :class="classNames">
-    <toggle-button
-      v-if="hasChildren"
-      :is-expanded="isExpanded"
-      @click="toggleExpanded"
-    />
-    <facet-link :alias="alias" :name="name" />
+    <div :class="`${blockName}__contents`">
+      <toggle-button
+        :has-children="hasChildren"
+        :is-expanded="isExpanded"
+        @click="toggleExpanded"
+      />
+      <facet-link :alias="alias" :name="name" />
+    </div>
     <slot :has-children="hasChildren" :is-expanded="isExpanded" :alias="alias" />
   </div>
 </template>
@@ -41,11 +43,12 @@ export default {
 
   data: () => ({
     isExpanded: false,
+    blockName: 'directory-facet',
   }),
 
   computed: {
     classNames() {
-      const blockName = 'directory-facet';
+      const { blockName } = this;
       const classNames = [blockName];
       if (this.isActive) classNames.push(`${blockName}--active`);
       return classNames;

--- a/packages/lazarus-shared/browser/directory-facets/graphql/directory-sections.js
+++ b/packages/lazarus-shared/browser/directory-facets/graphql/directory-sections.js
@@ -2,8 +2,8 @@ import gql from 'graphql-tag';
 
 export default gql`
 
-query RootDirectorySections($rootAlias: String!) {
-  websiteSectionAlias(input: { alias: $rootAlias }) {
+query DirectorySections($sectionAlias: String!) {
+  websiteSectionAlias(input: { alias: $sectionAlias }) {
     id
     name
     children(input: { sort: { field: name, order: asc }, pagination: { limit: 0 } }) {
@@ -12,6 +12,9 @@ query RootDirectorySections($rootAlias: String!) {
           id
           name
           alias
+          children(input: { pagination: { limit: 1 } }) {
+            totalCount
+          }
         }
       }
     }

--- a/packages/lazarus-shared/browser/directory-facets/graphql/root-sections.js
+++ b/packages/lazarus-shared/browser/directory-facets/graphql/root-sections.js
@@ -1,0 +1,21 @@
+import gql from 'graphql-tag';
+
+export default gql`
+
+query RootDirectorySections($rootAlias: String!) {
+  websiteSectionAlias(input: { alias: $rootAlias }) {
+    id
+    name
+    children(input: { sort: { field: name, order: asc }, pagination: { limit: 0 } }) {
+      edges {
+        node {
+          id
+          name
+          alias
+        }
+      }
+    }
+  }
+}
+
+`;

--- a/packages/lazarus-shared/browser/directory-facets/icons/_wrapper.vue
+++ b/packages/lazarus-shared/browser/directory-facets/icons/_wrapper.vue
@@ -1,0 +1,40 @@
+<template>
+  <tag
+    :is="tag"
+    v-if="name"
+    :class="classNames"
+    :modifers="modifiers"
+  >
+    <slot />
+  </tag>
+</template>
+
+<script>
+export default {
+  props: {
+    name: {
+      type: String,
+      required: true,
+      default: '',
+    },
+    modifiers: {
+      type: Array,
+      default: () => [],
+    },
+    tag: {
+      type: String,
+      default: 'span',
+    },
+  },
+  computed: {
+    classNames() {
+      const blockName = 'directory-facet-icon';
+      return [
+        blockName,
+        `${blockName}--${this.name}`,
+        ...this.modifiers.map(mod => `${blockName}--${mod}`),
+      ];
+    },
+  },
+};
+</script>

--- a/packages/lazarus-shared/browser/directory-facets/icons/add-circle-outline.vue
+++ b/packages/lazarus-shared/browser/directory-facets/icons/add-circle-outline.vue
@@ -1,0 +1,29 @@
+
+<template>
+  <icon-wrapper
+    name="add-circle-outline"
+    :tag="tag"
+    :modifiers="modifiers"
+  >
+    <!-- eslint-disable-next-line -->
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M13 7h-2v4H7v2h4v4h2v-4h4v-2h-4V7zm-1-5C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"/></svg>
+  </icon-wrapper>
+</template>
+
+<script>
+import IconWrapper from './_wrapper.vue';
+
+export default {
+  components: { IconWrapper },
+  props: {
+    modifiers: {
+      type: Array,
+      default: () => [],
+    },
+    tag: {
+      type: String,
+      default: 'span',
+    },
+  },
+};
+</script>

--- a/packages/lazarus-shared/browser/directory-facets/icons/filter-none.vue
+++ b/packages/lazarus-shared/browser/directory-facets/icons/filter-none.vue
@@ -1,0 +1,29 @@
+
+<template>
+  <icon-wrapper
+    name="filter-none"
+    :tag="tag"
+    :modifiers="modifiers"
+  >
+    <!-- eslint-disable-next-line -->
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0V0z"/><path d="M3 5H1v16c0 1.1.9 2 2 2h16v-2H3V5zm18-4H7c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V3c0-1.1-.9-2-2-2zm0 16H7V3h14v14z"/></svg>
+  </icon-wrapper>
+</template>
+
+<script>
+import IconWrapper from './_wrapper.vue';
+
+export default {
+  components: { IconWrapper },
+  props: {
+    modifiers: {
+      type: Array,
+      default: () => [],
+    },
+    tag: {
+      type: String,
+      default: 'span',
+    },
+  },
+};
+</script>

--- a/packages/lazarus-shared/browser/directory-facets/icons/remove-circle-outline.vue
+++ b/packages/lazarus-shared/browser/directory-facets/icons/remove-circle-outline.vue
@@ -1,0 +1,28 @@
+<template>
+  <icon-wrapper
+    name="remove-circle-outline"
+    :tag="tag"
+    :modifiers="modifiers"
+  >
+    <!-- eslint-disable-next-line -->
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M7 11v2h10v-2H7zm5-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"/></svg>
+  </icon-wrapper>
+</template>
+
+<script>
+import IconWrapper from './_wrapper.vue';
+
+export default {
+  components: { IconWrapper },
+  props: {
+    modifiers: {
+      type: Array,
+      default: () => [],
+    },
+    tag: {
+      type: String,
+      default: 'span',
+    },
+  },
+};
+</script>

--- a/packages/lazarus-shared/browser/directory-facets/index.vue
+++ b/packages/lazarus-shared/browser/directory-facets/index.vue
@@ -1,11 +1,28 @@
 <template>
-  <div />
+  <div
+    class="directory-facets"
+    :data-root-alias="rootAlias"
+    :data-active-alias="activeAlias"
+  />
 </template>
 
 <script>
 export default {
+  /**
+   *
+   */
+  props: {
+    rootAlias: {
+      type: String,
+      required: true,
+    },
+    activeAlias: {
+      type: String,
+      default: null,
+    },
+  },
   created() {
-    console.log('directory facets created!');
+    console.log({ rootAlias: this.rootAlias, activeAlias: this.activeAlias });
   },
 };
 </script>

--- a/packages/lazarus-shared/browser/directory-facets/index.vue
+++ b/packages/lazarus-shared/browser/directory-facets/index.vue
@@ -4,29 +4,39 @@
     :data-root-alias="rootAlias"
     :data-active-alias="activeAlias"
   >
-    <p v-if="isLoading">
-      Loading...
-    </p>
-    <p v-else-if="error">
-      Error: {{ error.message }}
-    </p>
-    <p
-      v-for="section in rootSections"
-      v-else
-      :key="section.id"
-    >
-      <a :href="`/${section.alias}`">
-        {{ section.name }}
-      </a>
-    </p>
+    <!-- <directory-facets-list :alias="rootAlias" /> -->
+    <div class="directory-facets__list">
+      <p v-if="isLoading">
+        Loading...
+      </p>
+      <p v-else-if="error">
+        Error: {{ error.message }}
+      </p>
+      <directory-facets-node
+        v-for="section in rootSections"
+        v-else
+        :key="section.id"
+        :alias="section.alias"
+        :name="section.name"
+        :child-count="section.children.totalCount"
+      />
+    </div>
   </div>
 </template>
 
 <script>
-import rootSectionsQuery from './graphql/root-sections';
+import DirectoryFacetsNode from './node.vue';
+import directorySectionsQuery from './graphql/directory-sections';
 import getEdgeNodes from './utils/get-edge-nodes';
 
 export default {
+  /**
+   *
+   */
+  components: {
+    DirectoryFacetsNode,
+  },
+
   /**
    *
    */
@@ -76,7 +86,7 @@ export default {
         this.isLoading = true;
         this.error = null;
         try {
-          this.rootSections = await this.loadRootSections();
+          this.rootSections = await this.loadSections();
           this.hasLoaded = true;
         } catch (e) {
           this.error = e;
@@ -86,9 +96,9 @@ export default {
       }
     },
 
-    async loadRootSections() {
-      const variables = { rootAlias: this.rootAlias };
-      const { data } = await this.$apollo.query({ query: rootSectionsQuery, variables });
+    async loadSections() {
+      const variables = { sectionAlias: this.rootAlias };
+      const { data } = await this.$apollo.query({ query: directorySectionsQuery, variables });
       this.loadType = 'all';
       return getEdgeNodes(data, 'websiteSectionAlias.children');
     },

--- a/packages/lazarus-shared/browser/directory-facets/index.vue
+++ b/packages/lazarus-shared/browser/directory-facets/index.vue
@@ -1,0 +1,11 @@
+<template>
+  <div />
+</template>
+
+<script>
+export default {
+  created() {
+    console.log('directory facets created!');
+  },
+};
+</script>

--- a/packages/lazarus-shared/browser/directory-facets/index.vue
+++ b/packages/lazarus-shared/browser/directory-facets/index.vue
@@ -4,37 +4,19 @@
     :data-root-alias="rootAlias"
     :data-active-alias="activeAlias"
   >
-    <!-- <directory-facets-list :alias="rootAlias" /> -->
-    <div class="directory-facets__list">
-      <p v-if="isLoading">
-        Loading...
-      </p>
-      <p v-else-if="error">
-        Error: {{ error.message }}
-      </p>
-      <directory-facets-node
-        v-for="section in rootSections"
-        v-else
-        :key="section.id"
-        :alias="section.alias"
-        :name="section.name"
-        :child-count="section.children.totalCount"
-      />
-    </div>
+    <directory-facets-list :alias="rootAlias" />
   </div>
 </template>
 
 <script>
-import DirectoryFacetsNode from './node.vue';
-import directorySectionsQuery from './graphql/directory-sections';
-import getEdgeNodes from './utils/get-edge-nodes';
+import DirectoryFacetsList from './list.vue';
 
 export default {
   /**
    *
    */
   components: {
-    DirectoryFacetsNode,
+    DirectoryFacetsList,
   },
 
   /**
@@ -48,59 +30,6 @@ export default {
     activeAlias: {
       type: String,
       default: null,
-    },
-  },
-
-  /**
-   *
-   */
-  data: () => ({
-    isLoading: false,
-    hasLoaded: false,
-    error: null,
-    rootSections: [],
-  }),
-
-  /**
-   *
-   */
-  computed: {
-    canLoad() {
-      return !this.isLoading || !this.hasLoaded;
-    },
-  },
-
-  /**
-   *
-   */
-  mounted() {
-    this.load();
-  },
-
-  /**
-   *
-   */
-  methods: {
-    async load() {
-      if (this.canLoad) {
-        this.isLoading = true;
-        this.error = null;
-        try {
-          this.rootSections = await this.loadSections();
-          this.hasLoaded = true;
-        } catch (e) {
-          this.error = e;
-        } finally {
-          this.isLoading = false;
-        }
-      }
-    },
-
-    async loadSections() {
-      const variables = { sectionAlias: this.rootAlias };
-      const { data } = await this.$apollo.query({ query: directorySectionsQuery, variables });
-      this.loadType = 'all';
-      return getEdgeNodes(data, 'websiteSectionAlias.children');
     },
   },
 };

--- a/packages/lazarus-shared/browser/directory-facets/index.vue
+++ b/packages/lazarus-shared/browser/directory-facets/index.vue
@@ -4,7 +4,7 @@
     :data-root-alias="rootAlias"
     :data-active-alias="activeAlias"
   >
-    <directory-facets-list :alias="rootAlias" />
+    <directory-facets-list :alias="rootAlias" :active-alias="activeAlias" />
   </div>
 </template>
 

--- a/packages/lazarus-shared/browser/directory-facets/index.vue
+++ b/packages/lazarus-shared/browser/directory-facets/index.vue
@@ -3,10 +3,29 @@
     class="directory-facets"
     :data-root-alias="rootAlias"
     :data-active-alias="activeAlias"
-  />
+  >
+    <p v-if="isLoading">
+      Loading...
+    </p>
+    <p v-else-if="error">
+      Error: {{ error.message }}
+    </p>
+    <p
+      v-for="section in rootSections"
+      v-else
+      :key="section.id"
+    >
+      <a :href="`/${section.alias}`">
+        {{ section.name }}
+      </a>
+    </p>
+  </div>
 </template>
 
 <script>
+import rootSectionsQuery from './graphql/root-sections';
+import getEdgeNodes from './utils/get-edge-nodes';
+
 export default {
   /**
    *
@@ -21,8 +40,58 @@ export default {
       default: null,
     },
   },
-  created() {
-    console.log({ rootAlias: this.rootAlias, activeAlias: this.activeAlias });
+
+  /**
+   *
+   */
+  data: () => ({
+    isLoading: false,
+    hasLoaded: false,
+    error: null,
+    rootSections: [],
+  }),
+
+  /**
+   *
+   */
+  computed: {
+    canLoad() {
+      return !this.isLoading || !this.hasLoaded;
+    },
+  },
+
+  /**
+   *
+   */
+  mounted() {
+    this.load();
+  },
+
+  /**
+   *
+   */
+  methods: {
+    async load() {
+      if (this.canLoad) {
+        this.isLoading = true;
+        this.error = null;
+        try {
+          this.rootSections = await this.loadRootSections();
+          this.hasLoaded = true;
+        } catch (e) {
+          this.error = e;
+        } finally {
+          this.isLoading = false;
+        }
+      }
+    },
+
+    async loadRootSections() {
+      const variables = { rootAlias: this.rootAlias };
+      const { data } = await this.$apollo.query({ query: rootSectionsQuery, variables });
+      this.loadType = 'all';
+      return getEdgeNodes(data, 'websiteSectionAlias.children');
+    },
   },
 };
 </script>

--- a/packages/lazarus-shared/browser/directory-facets/index.vue
+++ b/packages/lazarus-shared/browser/directory-facets/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    :class="blockName"
+    :class="classNames"
     :data-root-alias="rootAlias"
     :data-active-alias="activeAlias"
   >
@@ -38,10 +38,23 @@ export default {
       type: String,
       default: 'Categories',
     },
+    modifiers: {
+      type: Array,
+      default: () => [],
+    },
   },
 
   data: () => ({
     blockName: 'directory-facets',
   }),
+
+  computed: {
+    classNames() {
+      const { blockName } = this;
+      const classNames = [blockName];
+      this.modifiers.forEach(mod => classNames.push(`${blockName}--${mod}`));
+      return classNames;
+    },
+  },
 };
 </script>

--- a/packages/lazarus-shared/browser/directory-facets/index.vue
+++ b/packages/lazarus-shared/browser/directory-facets/index.vue
@@ -1,9 +1,12 @@
 <template>
   <div
-    class="directory-facets"
+    :class="blockName"
     :data-root-alias="rootAlias"
     :data-active-alias="activeAlias"
   >
+    <div :class="`${blockName}__header`">
+      {{ header }}
+    </div>
     <directory-facets-list :alias="rootAlias" :active-alias="activeAlias" />
   </div>
 </template>
@@ -31,6 +34,14 @@ export default {
       type: String,
       default: null,
     },
+    header: {
+      type: String,
+      default: 'Categories',
+    },
   },
+
+  data: () => ({
+    blockName: 'directory-facets',
+  }),
 };
 </script>

--- a/packages/lazarus-shared/browser/directory-facets/link.vue
+++ b/packages/lazarus-shared/browser/directory-facets/link.vue
@@ -1,0 +1,20 @@
+<template>
+  <a class="directory-facets__link" :href="`/${alias}`">
+    {{ name }}
+  </a>
+</template>
+
+<script>
+export default {
+  props: {
+    alias: {
+      type: String,
+      required: true,
+    },
+    name: {
+      type: String,
+      required: true,
+    },
+  },
+};
+</script>

--- a/packages/lazarus-shared/browser/directory-facets/link.vue
+++ b/packages/lazarus-shared/browser/directory-facets/link.vue
@@ -1,5 +1,5 @@
 <template>
-  <a class="directory-facets__link" :href="`/${alias}`">
+  <a class="directory-facet__link" :href="`/${alias}`">
     {{ name }}
   </a>
 </template>

--- a/packages/lazarus-shared/browser/directory-facets/list.vue
+++ b/packages/lazarus-shared/browser/directory-facets/list.vue
@@ -1,8 +1,6 @@
 <template>
   <div class="directory-facets__list">
-    <p v-if="isLoading">
-      Loading...
-    </p>
+    <loading-spinner v-if="isLoading" />
     <p v-else-if="error">
       Error: {{ error.message }}
     </p>
@@ -28,6 +26,7 @@
 
 <script>
 import DirectoryFacet from './facet.vue';
+import LoadingSpinner from './loading-spinner.vue';
 import directorySectionsQuery from './graphql/directory-sections';
 import getEdgeNodes from './utils/get-edge-nodes';
 
@@ -35,6 +34,7 @@ export default {
   name: 'DirectoryFacetsList',
   components: {
     DirectoryFacet,
+    LoadingSpinner,
   },
 
   /**

--- a/packages/lazarus-shared/browser/directory-facets/list.vue
+++ b/packages/lazarus-shared/browser/directory-facets/list.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="directory-facets__list" />
+</template>
+
+<script>
+export default {
+  name: 'DirectoryFacetsList',
+  props: {
+    alias: {
+      type: String,
+      required: true,
+    },
+  },
+  data: () => ({
+    isLoading: false,
+    hasLoaded: false,
+    error: null,
+  }),
+};
+</script>

--- a/packages/lazarus-shared/browser/directory-facets/list.vue
+++ b/packages/lazarus-shared/browser/directory-facets/list.vue
@@ -78,7 +78,6 @@ export default {
         this.error = null;
         try {
           this.sections = await this.loadSections();
-          console.log(this.sections);
           this.hasLoaded = true;
         } catch (e) {
           this.error = e;

--- a/packages/lazarus-shared/browser/directory-facets/list.vue
+++ b/packages/lazarus-shared/browser/directory-facets/list.vue
@@ -13,9 +13,14 @@
       :alias="section.alias"
       :name="section.name"
       :child-count="section.children.totalCount"
+      :active-alias="activeAlias"
     >
       <template #default="{ hasChildren, isExpanded, alias }">
-        <directory-facets-list v-if="hasChildren && isExpanded" :alias="alias" />
+        <directory-facets-list
+          v-if="hasChildren && isExpanded"
+          :alias="alias"
+          :active-alias="activeAlias"
+        />
       </template>
     </directory-facets-node>
   </div>
@@ -39,6 +44,10 @@ export default {
     alias: {
       type: String,
       required: true,
+    },
+    activeAlias: {
+      type: String,
+      default: null,
     },
   },
 

--- a/packages/lazarus-shared/browser/directory-facets/list.vue
+++ b/packages/lazarus-shared/browser/directory-facets/list.vue
@@ -1,20 +1,98 @@
 <template>
-  <div class="directory-facets__list" />
+  <div class="directory-facets__list">
+    <p v-if="isLoading">
+      Loading...
+    </p>
+    <p v-else-if="error">
+      Error: {{ error.message }}
+    </p>
+    <directory-facets-node
+      v-for="section in sections"
+      v-else
+      :key="section.id"
+      :alias="section.alias"
+      :name="section.name"
+      :child-count="section.children.totalCount"
+    >
+      <template #default="{ hasChildren, isExpanded, alias }">
+        <directory-facets-list v-if="hasChildren && isExpanded" :alias="alias" />
+      </template>
+    </directory-facets-node>
+  </div>
 </template>
 
 <script>
+import DirectoryFacetsNode from './node.vue';
+import directorySectionsQuery from './graphql/directory-sections';
+import getEdgeNodes from './utils/get-edge-nodes';
+
 export default {
   name: 'DirectoryFacetsList',
+  components: {
+    DirectoryFacetsNode,
+  },
+
+  /**
+   *
+   */
   props: {
     alias: {
       type: String,
       required: true,
     },
   },
+
+  /**
+   *
+   */
   data: () => ({
     isLoading: false,
     hasLoaded: false,
     error: null,
+    sections: [],
   }),
+
+  /**
+   *
+   */
+  computed: {
+    canLoad() {
+      return !this.isLoading || !this.hasLoaded;
+    },
+  },
+
+  /**
+   *
+   */
+  mounted() {
+    this.load();
+  },
+
+  /**
+   *
+   */
+  methods: {
+    async load() {
+      if (this.canLoad) {
+        this.isLoading = true;
+        this.error = null;
+        try {
+          this.sections = await this.loadSections();
+          console.log(this.sections);
+          this.hasLoaded = true;
+        } catch (e) {
+          this.error = e;
+        } finally {
+          this.isLoading = false;
+        }
+      }
+    },
+
+    async loadSections() {
+      const variables = { sectionAlias: this.alias };
+      const { data } = await this.$apollo.query({ query: directorySectionsQuery, variables });
+      return getEdgeNodes(data, 'websiteSectionAlias.children');
+    },
+  },
 };
 </script>

--- a/packages/lazarus-shared/browser/directory-facets/list.vue
+++ b/packages/lazarus-shared/browser/directory-facets/list.vue
@@ -6,7 +6,7 @@
     <p v-else-if="error">
       Error: {{ error.message }}
     </p>
-    <directory-facets-node
+    <directory-facet
       v-for="section in sections"
       v-else
       :key="section.id"
@@ -22,19 +22,19 @@
           :active-alias="activeAlias"
         />
       </template>
-    </directory-facets-node>
+    </directory-facet>
   </div>
 </template>
 
 <script>
-import DirectoryFacetsNode from './node.vue';
+import DirectoryFacet from './facet.vue';
 import directorySectionsQuery from './graphql/directory-sections';
 import getEdgeNodes from './utils/get-edge-nodes';
 
 export default {
   name: 'DirectoryFacetsList',
   components: {
-    DirectoryFacetsNode,
+    DirectoryFacet,
   },
 
   /**

--- a/packages/lazarus-shared/browser/directory-facets/loading-spinner.vue
+++ b/packages/lazarus-shared/browser/directory-facets/loading-spinner.vue
@@ -1,0 +1,25 @@
+<template>
+  <div :class="blockName">
+    <div :class="`${blockName}__spinner`" role="status" />
+    <span :class="`${blockName}__message`">{{ message }}</span>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    message: {
+      type: String,
+      default: 'Loading categories...',
+    },
+    modifiers: {
+      type: Array,
+      default: () => [],
+    },
+  },
+
+  data: () => ({
+    blockName: 'directory-facet-loading',
+  }),
+};
+</script>

--- a/packages/lazarus-shared/browser/directory-facets/node.vue
+++ b/packages/lazarus-shared/browser/directory-facets/node.vue
@@ -45,10 +45,6 @@ export default {
     },
   },
 
-  created() {
-    console.log(this.name);
-  },
-
   methods: {
     toggleExpanded() {
       this.isExpanded = !this.isExpanded;

--- a/packages/lazarus-shared/browser/directory-facets/node.vue
+++ b/packages/lazarus-shared/browser/directory-facets/node.vue
@@ -1,21 +1,22 @@
 <template>
   <div class="directory-facets__node">
     <toggle-button
-      :can-expand="hasChildren"
+      v-if="hasChildren"
       :is-expanded="isExpanded"
       @click="toggleExpanded"
     />
-    <a :href="`/${alias}`">
-      {{ name }}
-    </a>
+    <node-link :alias="alias" :name="name" />
+    <slot :has-children="hasChildren" :is-expanded="isExpanded" :alias="alias" />
   </div>
 </template>
 
 <script>
+import NodeLink from './link.vue';
 import ToggleButton from './toggle-button.vue';
 
 export default {
   components: {
+    NodeLink,
     ToggleButton,
   },
 
@@ -42,6 +43,10 @@ export default {
     hasChildren() {
       return Boolean(this.childCount);
     },
+  },
+
+  created() {
+    console.log(this.name);
   },
 
   methods: {

--- a/packages/lazarus-shared/browser/directory-facets/node.vue
+++ b/packages/lazarus-shared/browser/directory-facets/node.vue
@@ -1,0 +1,53 @@
+<template>
+  <div class="directory-facets__node">
+    <toggle-button
+      :can-expand="hasChildren"
+      :is-expanded="isExpanded"
+      @click="toggleExpanded"
+    />
+    <a :href="`/${alias}`">
+      {{ name }}
+    </a>
+  </div>
+</template>
+
+<script>
+import ToggleButton from './toggle-button.vue';
+
+export default {
+  components: {
+    ToggleButton,
+  },
+
+  props: {
+    alias: {
+      type: String,
+      required: true,
+    },
+    name: {
+      type: String,
+      required: true,
+    },
+    childCount: {
+      type: Number,
+      default: 0,
+    },
+  },
+
+  data: () => ({
+    isExpanded: false,
+  }),
+
+  computed: {
+    hasChildren() {
+      return Boolean(this.childCount);
+    },
+  },
+
+  methods: {
+    toggleExpanded() {
+      this.isExpanded = !this.isExpanded;
+    },
+  },
+};
+</script>

--- a/packages/lazarus-shared/browser/directory-facets/node.vue
+++ b/packages/lazarus-shared/browser/directory-facets/node.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="directory-facets__node">
+  <div :class="classNames">
     <toggle-button
       v-if="hasChildren"
       :is-expanded="isExpanded"
@@ -33,6 +33,10 @@ export default {
       type: Number,
       default: 0,
     },
+    activeAlias: {
+      type: String,
+      default: null,
+    },
   },
 
   data: () => ({
@@ -40,9 +44,24 @@ export default {
   }),
 
   computed: {
+    classNames() {
+      const elementName = 'directory-facets__node';
+      const classNames = [elementName];
+      if (this.isActive) classNames.push(`${elementName}--active`);
+      return classNames;
+    },
     hasChildren() {
       return Boolean(this.childCount);
     },
+    isActive() {
+      const { alias, activeAlias } = this;
+      if (!activeAlias) return false;
+      return activeAlias.indexOf(alias) === 0;
+    },
+  },
+
+  mounted() {
+    if (this.isActive) this.isExpanded = true;
   },
 
   methods: {

--- a/packages/lazarus-shared/browser/directory-facets/toggle-button.vue
+++ b/packages/lazarus-shared/browser/directory-facets/toggle-button.vue
@@ -1,5 +1,5 @@
 <template>
-  <button class="directory-facets__toggle-button" :disabled="!canExpand" @click="$emit('click')">
+  <button class="directory-facets__toggle-button" @click="$emit('click')">
     {{ label }}
   </button>
 </template>
@@ -7,10 +7,6 @@
 <script>
 export default {
   props: {
-    canExpand: {
-      type: Boolean,
-      default: false,
-    },
     isExpanded: {
       type: Boolean,
       default: false,

--- a/packages/lazarus-shared/browser/directory-facets/toggle-button.vue
+++ b/packages/lazarus-shared/browser/directory-facets/toggle-button.vue
@@ -1,22 +1,37 @@
 <template>
-  <button class="directory-facet__toggle-button" @click="$emit('click')">
-    {{ label }}
+  <button class="directory-facet__toggle-button" :disabled="!hasChildren" @click="$emit('click')">
+    <component :is="icon" />
   </button>
 </template>
 
 <script>
+import PlusIcon from './icons/add-circle-outline.vue';
+import MinusIcon from './icons/remove-circle-outline.vue';
+import FilterIcon from './icons/filter-none.vue';
+
 export default {
+  components: {
+    PlusIcon,
+    MinusIcon,
+    FilterIcon,
+  },
+
   props: {
     isExpanded: {
+      type: Boolean,
+      default: false,
+    },
+    hasChildren: {
       type: Boolean,
       default: false,
     },
   },
 
   computed: {
-    label() {
-      if (this.isExpanded) return '-';
-      return '+';
+    icon() {
+      if (!this.hasChildren) return 'filter-icon';
+      if (this.isExpanded) return 'minus-icon';
+      return 'plus-icon';
     },
   },
 };

--- a/packages/lazarus-shared/browser/directory-facets/toggle-button.vue
+++ b/packages/lazarus-shared/browser/directory-facets/toggle-button.vue
@@ -1,5 +1,5 @@
 <template>
-  <button class="directory-facets__toggle-button" @click="$emit('click')">
+  <button class="directory-facet__toggle-button" @click="$emit('click')">
     {{ label }}
   </button>
 </template>

--- a/packages/lazarus-shared/browser/directory-facets/toggle-button.vue
+++ b/packages/lazarus-shared/browser/directory-facets/toggle-button.vue
@@ -1,0 +1,27 @@
+<template>
+  <button class="directory-facets__toggle-button" :disabled="!canExpand" @click="$emit('click')">
+    {{ label }}
+  </button>
+</template>
+
+<script>
+export default {
+  props: {
+    canExpand: {
+      type: Boolean,
+      default: false,
+    },
+    isExpanded: {
+      type: Boolean,
+      default: false,
+    },
+  },
+
+  computed: {
+    label() {
+      if (this.isExpanded) return '-';
+      return '+';
+    },
+  },
+};
+</script>

--- a/packages/lazarus-shared/browser/directory-facets/utils/get-as-array.js
+++ b/packages/lazarus-shared/browser/directory-facets/utils/get-as-array.js
@@ -1,0 +1,6 @@
+import { get } from 'object-path';
+
+export default (obj, path) => {
+  const v = get(obj, path, []);
+  return Array.isArray(v) ? v : [];
+};

--- a/packages/lazarus-shared/browser/directory-facets/utils/get-as-object.js
+++ b/packages/lazarus-shared/browser/directory-facets/utils/get-as-object.js
@@ -1,0 +1,6 @@
+import { get } from 'object-path';
+
+export default (obj, path) => {
+  const v = get(obj, path, {});
+  return v && typeof v === 'object' ? v : {};
+};

--- a/packages/lazarus-shared/browser/directory-facets/utils/get-edge-nodes.js
+++ b/packages/lazarus-shared/browser/directory-facets/utils/get-edge-nodes.js
@@ -1,0 +1,3 @@
+import getAsArray from './get-as-array';
+
+export default (obj, path) => getAsArray(obj, `${path}.edges`).map(edge => edge.node);

--- a/packages/lazarus-shared/browser/index.js
+++ b/packages/lazarus-shared/browser/index.js
@@ -10,6 +10,7 @@ import IncrementAdPos from './increment-ad-pos.vue';
 import LoadEloquaIframes from './load-eloqua-iframes.vue';
 
 const GallerySlideshow = () => import(/* webpackChunkName: "lazarus-shared-gallery-slideshow" */ './gallery-slideshow/index.vue');
+const DirectoryFacets = () => import(/* webpackChunkName: "lazarus-shared-directory-facets" */ './directory-facets/index.vue');
 
 export default (Browser) => {
   DefaultTheme(Browser);
@@ -27,5 +28,8 @@ export default (Browser) => {
   Browser.register('LazarusSharedLoadEloquaIframes', LoadEloquaIframes);
   Browser.register('LazarusSharedGallerySlideshow', GallerySlideshow, {
     provide: { EventBus },
+  });
+  Browser.register('LazarusSharedDirectoryFacets', DirectoryFacets, {
+    withApollo: true,
   });
 };

--- a/packages/lazarus-shared/components/directory-facets.marko
+++ b/packages/lazarus-shared/components/directory-facets.marko
@@ -1,0 +1,1 @@
+<marko-web-browser-component name="LazarusSharedDirectoryFacets" />

--- a/packages/lazarus-shared/components/directory-facets.marko
+++ b/packages/lazarus-shared/components/directory-facets.marko
@@ -1,8 +1,10 @@
 import defaultValue from "@base-cms/marko-core/utils/default-value";
+import { getAsArray } from "@base-cms/object-path";
 
 $ const props = {
   rootAlias: defaultValue(input.rootAlias, "directory"),
   activeAlias: input.activeAlias,
+  modifiers: getAsArray(input, "modifiers"),
 };
 
 <marko-web-browser-component name="LazarusSharedDirectoryFacets" props=props />

--- a/packages/lazarus-shared/components/directory-facets.marko
+++ b/packages/lazarus-shared/components/directory-facets.marko
@@ -1,1 +1,8 @@
-<marko-web-browser-component name="LazarusSharedDirectoryFacets" />
+import defaultValue from "@base-cms/marko-core/utils/default-value";
+
+$ const props = {
+  rootAlias: defaultValue(input.rootAlias, "directory"),
+  activeAlias: input.activeAlias,
+};
+
+<marko-web-browser-component name="LazarusSharedDirectoryFacets" props=props />

--- a/packages/lazarus-shared/components/flows/content-load-more.marko
+++ b/packages/lazarus-shared/components/flows/content-load-more.marko
@@ -1,6 +1,7 @@
 import { getAsArray, getAsObject } from "@base-cms/object-path";
 
 $ const nodes = getAsArray(input, "nodes");
+$ const image = getAsObject(input, "node.image");
 $ const adunit = getAsObject(input, "adunit");
 
 <if(nodes.length)>
@@ -23,8 +24,11 @@ $ const adunit = getAsObject(input, "adunit");
       inner-justified=false
       modifiers=["feed"]
     >
-      <@node>
-        <@image width=180 />
+      <@node ...input.node>
+        <@image
+          width=180
+          ...image
+        />
       </@node>
     </lazarus-shared-content-list-flow>
   </lazarus-skin-page-grid-col>

--- a/packages/lazarus-shared/components/marko.json
+++ b/packages/lazarus-shared/components/marko.json
@@ -31,5 +31,8 @@
     "template": "./gallery-slideshow.marko",
     "@active-slide-number": "number",
     "@images": "array"
+  },
+  "<lazarus-shared-directory-facets>": {
+    "template": "./directory-facets.marko"
   }
 }

--- a/packages/lazarus-shared/components/marko.json
+++ b/packages/lazarus-shared/components/marko.json
@@ -33,6 +33,9 @@
     "@images": "array"
   },
   "<lazarus-shared-directory-facets>": {
-    "template": "./directory-facets.marko"
+    "template": "./directory-facets.marko",
+    "@root-alias": "string",
+    "@active-alias": "string",
+    "@modifiers": "array"
   }
 }

--- a/packages/lazarus-shared/components/nodes/content-page-card.marko
+++ b/packages/lazarus-shared/components/nodes/content-page-card.marko
@@ -13,6 +13,7 @@ $ const isSponsored = getAsArray(content, "labels").includes("Sponsored");
 $ const { type } = content;
 
 $ const hasImage = Boolean(primaryImage.src);
+$ const isLogo = defaultValue(primaryImage.isLogo, false);
 $ const imgInput = getAsObject(input, "image");
 $ const imgWidth = defaultValue(imgInput.width, 768);
 $ const imgAspect = defaultValue(imgInput.ar, "16:9");
@@ -23,8 +24,8 @@ $ const srcset = [`${buildImgixUrl(src, { dpr: 2 })} 2x`];
 
 $ const hasEmbedCode = Boolean(content.embedCode);
 
-$ const displayPrimaryImage = !hasEmbedCode && hasImage && type !== "media-gallery";
-$ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? false : true;
+$ const displayPrimaryImage = !hasEmbedCode && hasImage && type !== "media-gallery" && !isLogo;
+$ const displayPublishedDate = ["event", "webinar", "contact", "company"].includes(type) ? false : true;
 
 <!-- @todo add lower-right image caption -->
 <marko-web-block
@@ -72,6 +73,14 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
         block-name=blockName
         obj=content
       />
+
+      <if(isLogo)>
+        <marko-web-page-image
+          obj=primaryImage
+          fluid=false
+          width=250
+        />
+      </if>
 
       <if(type !== "contact")>
         <default-theme-content-attribution obj=content />

--- a/packages/lazarus-shared/graphql/fragments/directory-page.js
+++ b/packages/lazarus-shared/graphql/fragments/directory-page.js
@@ -1,0 +1,14 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+fragment WebsiteSectionDirectoryPageFragment on WebsiteSection {
+  id
+  name
+  description
+  hierarchy {
+    id
+    alias
+    name
+  }
+}
+`;

--- a/packages/lazarus-shared/package.json
+++ b/packages/lazarus-shared/package.json
@@ -30,6 +30,7 @@
     "cheerio": "^1.0.0-rc.3",
     "graphql": "^14.5.4",
     "graphql-tag": "^2.10.1",
+    "object-path": "^0.11.4",
     "newrelic": "^5.11.0",
     "node-fetch": "^2.6.0",
     "vue-recaptcha": "^1.2.0"

--- a/packages/lazarus-shared/routes/website-section.js
+++ b/packages/lazarus-shared/routes/website-section.js
@@ -1,12 +1,24 @@
 const { withWebsiteSection } = require('@base-cms/marko-web/middleware');
 const section = require('../templates/website-section');
 const contactUs = require('../templates/website-section/contact-us');
+const directory = require('../templates/website-section/directory');
 const queryFragment = require('../graphql/fragments/website-section-page');
+const directoryFragment = require('../graphql/fragments/directory-page');
 
 module.exports = (app) => {
   app.get('/:alias(contact-us)', withWebsiteSection({
     template: contactUs,
     queryFragment,
+  }));
+
+  app.get('/:alias(directory)', withWebsiteSection({
+    template: directory,
+    queryFragment: directoryFragment,
+  }));
+
+  app.get('/:alias(directory/[a-z0-9-/]+)', withWebsiteSection({
+    template: directory,
+    queryFragment: directoryFragment,
   }));
 
   app.get('/:alias([a-z0-9-/]+)', withWebsiteSection({

--- a/packages/lazarus-shared/scss/_directory-facets.scss
+++ b/packages/lazarus-shared/scss/_directory-facets.scss
@@ -1,0 +1,10 @@
+.directory-facets {
+  $self: &;
+  &__list {
+    #{ $self } {
+      &__list {
+        padding: $grid-gutter-width / 2;
+      }
+    }
+  }
+}

--- a/packages/lazarus-shared/scss/_directory-facets.scss
+++ b/packages/lazarus-shared/scss/_directory-facets.scss
@@ -7,4 +7,12 @@
       }
     }
   }
+
+  &__node {
+    &--active {
+      > a {
+        font-weight: 600;
+      }
+    }
+  }
 }

--- a/packages/lazarus-shared/scss/_directory-facets.scss
+++ b/packages/lazarus-shared/scss/_directory-facets.scss
@@ -1,9 +1,10 @@
 .directory-facets {
   $self: &;
   &__list {
+    margin-bottom: 5px;
     #{ $self } {
       &__list {
-        padding: $grid-gutter-width / 2;
+        padding-left: 21px;
       }
     }
   }
@@ -11,9 +12,48 @@
 
 .directory-facet {
   $self: &;
+  margin-bottom: 2px;
+
+  &__contents {
+    display: inline-flex;
+    flex-direction: row;
+  }
+
+  &__toggle-button {
+    align-self: flex-start;
+    padding: 0;
+    margin: 0;
+    font-size: 16px;
+    font-weight: 400;
+    line-height: 1.5;
+    color: $gray-700;
+    text-align: left;
+    text-decoration: none;
+    text-transform: none;
+    cursor: pointer;
+    user-select: none;
+    background: none;
+    border: none;
+    outline: none;
+    -webkit-tap-highlight-color: transparent;
+
+    &:focus,
+    &:active {
+      outline: none;
+    }
+  }
+
+  &__link {
+    margin-left: 5px;
+    word-break: break-word;
+  }
+
   &--active {
-    > #{ $self }__link {
+    > #{ $self }__contents {
       font-weight: 600;
+      #{ $self }__link {
+        color: darken($primary, 20%);
+      }
     }
   }
 }
@@ -42,5 +82,20 @@
 
   &__message {
     margin-left: 5px;
+  }
+}
+
+.directory-facet-icon {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  color: $gray-700;
+
+  svg {
+    width: 16px;
+    height: 16px;
+    overflow: hidden;
+    vertical-align: middle;
+    fill: currentColor;
   }
 }

--- a/packages/lazarus-shared/scss/_directory-facets.scss
+++ b/packages/lazarus-shared/scss/_directory-facets.scss
@@ -1,5 +1,11 @@
 .directory-facets {
   $self: &;
+  &__header {
+    @include theme-card-header();
+    display: inline-block;
+    margin-bottom: .75rem;
+  }
+
   &__list {
     margin-bottom: 5px;
     #{ $self } {

--- a/packages/lazarus-shared/scss/_directory-facets.scss
+++ b/packages/lazarus-shared/scss/_directory-facets.scss
@@ -7,12 +7,13 @@
       }
     }
   }
+}
 
-  &__node {
-    &--active {
-      > a {
-        font-weight: 600;
-      }
+.directory-facet {
+  $self: &;
+  &--active {
+    > #{ $self }__link {
+      font-weight: 600;
     }
   }
 }

--- a/packages/lazarus-shared/scss/_directory-facets.scss
+++ b/packages/lazarus-shared/scss/_directory-facets.scss
@@ -17,3 +17,30 @@
     }
   }
 }
+
+@keyframes directory-loading-spinner {
+  0% {
+    transform: scale(0);
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+.directory-facet-loading {
+  &__spinner {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    color: $primary;
+    vertical-align: text-bottom;
+    background-color: currentColor;
+    border-radius: 50%;
+    opacity: 0;
+    animation: directory-loading-spinner .75s linear infinite;
+  }
+
+  &__message {
+    margin-left: 5px;
+  }
+}

--- a/packages/lazarus-shared/templates/website-section/directory.marko
+++ b/packages/lazarus-shared/templates/website-section/directory.marko
@@ -1,6 +1,12 @@
 import queryFragment from "@endeavor-business-media/lazarus-shared/graphql/fragments/content-list";
 
-$ const { id, alias, name, pageNode } = data;
+$ const {
+  id,
+  alias,
+  name,
+  pageNode,
+  rootAlias,
+} = data;
 
 <marko-web-website-section-page-layout id=id alias=alias name=name>
   <@head>
@@ -39,7 +45,49 @@ $ const { id, alias, name, pageNode } = data;
 
       <marko-web-page-wrapper modifiers=["website-section-contents"]>
         <@section>
-          <lazarus-skin-page-grid>
+          <div class="directory-grid">
+            <div class="directory-grid__left-col">
+              <lazarus-shared-directory-facets root-alias=rootAlias active-alias=alias />
+            </div>
+            <div class="directory-grid__right-col">
+              <marko-web-query|{ nodes }|
+                name="website-scheduled-content"
+                params={ sectionId: id, limit: 12, queryFragment }
+              >
+                <lazarus-shared-content-list-flow
+                  nodes=nodes
+                  flush-x=true
+                  flush-y=true
+                  inner-justified=false
+                  modifiers=["feed"]
+                >
+                  <@node with-dates=false>
+                    <@image width=120 />
+                  </@node>
+                </lazarus-shared-content-list-flow>
+              </marko-web-query>
+
+              <marko-web-load-more
+                append-to=".directory-grid__right-col"
+                expand=500
+                component-name="lazarus-shared-content-load-more-flow"
+                component-input={
+                  node: { image: { width: 120 }, withDates: false },
+                  adunit: {
+                    location: "taxonomy",
+                    position: "infinitescroll",
+                    context: { sectionId: section.id },
+                  },
+                }
+                fragment-name="content-list"
+                query-name="website-scheduled-content"
+                query-params={ sectionId: id, limit: 12, skip: 12 }
+                page-input={ for: "website-section", id }
+              />
+            </div>
+          </div>
+
+          <!-- <lazarus-skin-page-grid modifiers=["wrap-left-col"]>
             <@left-col>
               <lazarus-shared-directory-facets active-alias=alias />
             </@left-col>
@@ -83,7 +131,7 @@ $ const { id, alias, name, pageNode } = data;
                 />
               </@bottom-row>
             </@right-col>
-          </lazarus-skin-page-grid>
+          </lazarus-skin-page-grid> -->
         </@section>
       </marko-web-page-wrapper>
     </marko-web-resolve-page>

--- a/packages/lazarus-shared/templates/website-section/directory.marko
+++ b/packages/lazarus-shared/templates/website-section/directory.marko
@@ -39,14 +39,33 @@ $ const { id, alias, name, pageNode } = data;
 
       <marko-web-page-wrapper modifiers=["website-section-contents"]>
         <@section>
-          <div class="row">
-            <aside class="col-lg-4">
+          <lazarus-skin-page-grid>
+            <@left-col>
               Left
-            </aside>
-            <div class="col-lg-8">
-              Right
-            </div>
-          </div>
+            </@left-col>
+            <@right-col>
+              <@bottom-row>
+                <marko-web-query|{ nodes }|
+                  name="website-scheduled-content"
+                  params={ sectionId: id, limit: 12, queryFragment }
+                >
+                  <lazarus-skin-page-grid-col modifiers=["full"]>
+                    <lazarus-shared-content-list-flow
+                      nodes=nodes
+                      flush-x=true
+                      flush-y=true
+                      inner-justified=false
+                      modifiers=["feed", "full-width"]
+                    >
+                      <@node>
+                        <@image width=120 />
+                      </@node>
+                    </lazarus-shared-content-list-flow>
+                  </lazarus-skin-page-grid-col>
+                </marko-web-query>
+              </@bottom-row>
+            </@right-col>
+          </lazarus-skin-page-grid>
         </@section>
       </marko-web-page-wrapper>
     </marko-web-resolve-page>

--- a/packages/lazarus-shared/templates/website-section/directory.marko
+++ b/packages/lazarus-shared/templates/website-section/directory.marko
@@ -57,7 +57,7 @@ $ const { id, alias, name, pageNode } = data;
                       inner-justified=false
                       modifiers=["feed"]
                     >
-                      <@node>
+                      <@node with-dates=false>
                         <@image width=120 />
                       </@node>
                     </lazarus-shared-content-list-flow>
@@ -69,7 +69,7 @@ $ const { id, alias, name, pageNode } = data;
                   expand=500
                   component-name="lazarus-shared-content-load-more-flow"
                   component-input={
-                    node: { image: { width: 120 } },
+                    node: { image: { width: 120 }, withDates: false },
                     adunit: {
                       location: "taxonomy",
                       position: "infinitescroll",

--- a/packages/lazarus-shared/templates/website-section/directory.marko
+++ b/packages/lazarus-shared/templates/website-section/directory.marko
@@ -55,7 +55,7 @@ $ const { id, alias, name, pageNode } = data;
                       flush-x=true
                       flush-y=true
                       inner-justified=false
-                      modifiers=["feed", "full-width"]
+                      modifiers=["feed"]
                     >
                       <@node>
                         <@image width=120 />
@@ -63,6 +63,24 @@ $ const { id, alias, name, pageNode } = data;
                     </lazarus-shared-content-list-flow>
                   </lazarus-skin-page-grid-col>
                 </marko-web-query>
+
+                <marko-web-load-more
+                  append-to=".page-grid__bottom-row"
+                  expand=500
+                  component-name="lazarus-shared-content-load-more-flow"
+                  component-input={
+                    node: { image: { width: 120 } },
+                    adunit: {
+                      location: "taxonomy",
+                      position: "infinitescroll",
+                      context: { sectionId: section.id },
+                    },
+                  }
+                  fragment-name="content-list"
+                  query-name="website-scheduled-content"
+                  query-params={ sectionId: id, limit: 12, skip: 12 }
+                  page-input={ for: "website-section", id }
+                />
               </@bottom-row>
             </@right-col>
           </lazarus-skin-page-grid>

--- a/packages/lazarus-shared/templates/website-section/directory.marko
+++ b/packages/lazarus-shared/templates/website-section/directory.marko
@@ -41,8 +41,7 @@ $ const { id, alias, name, pageNode } = data;
         <@section>
           <lazarus-skin-page-grid>
             <@left-col>
-              Left
-              <lazarus-shared-directory-facets />
+              <lazarus-shared-directory-facets active-alias=alias />
             </@left-col>
             <@right-col>
               <@bottom-row>

--- a/packages/lazarus-shared/templates/website-section/directory.marko
+++ b/packages/lazarus-shared/templates/website-section/directory.marko
@@ -42,6 +42,7 @@ $ const { id, alias, name, pageNode } = data;
           <lazarus-skin-page-grid>
             <@left-col>
               Left
+              <lazarus-shared-directory-facets />
             </@left-col>
             <@right-col>
               <@bottom-row>

--- a/packages/lazarus-shared/templates/website-section/directory.marko
+++ b/packages/lazarus-shared/templates/website-section/directory.marko
@@ -5,8 +5,9 @@ $ const {
   alias,
   name,
   pageNode,
-  rootAlias,
 } = data;
+$ const aliasParts = alias.split("/");
+$ const rootAlias = aliasParts.shift();
 
 <marko-web-website-section-page-layout id=id alias=alias name=name>
   <@head>

--- a/packages/lazarus-shared/templates/website-section/directory.marko
+++ b/packages/lazarus-shared/templates/website-section/directory.marko
@@ -1,0 +1,62 @@
+import queryFragment from "@endeavor-business-media/lazarus-shared/graphql/fragments/content-list";
+
+$ const { id, alias, name, pageNode } = data;
+
+<marko-web-website-section-page-layout id=id alias=alias name=name>
+  <@head>
+    <marko-web-gtm-website-section-context|{ context }| alias=alias>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-website-section-context>
+  </@head>
+  <@page>
+    <marko-web-resolve-page|{ data: section, resolved }| node=pageNode>
+      <informa-gam-adunit
+        location="taxonomy"
+        position="top_banner"
+        modifiers=["top-of-page"]
+      >
+        <@context section-id=section.id />
+      </informa-gam-adunit>
+
+      <marko-web-page-wrapper modifiers=["website-section-header", "top-border"]>
+        <@section>
+          <default-theme-website-section-breadcrumbs display-self=false section=section />
+          <marko-web-website-section-name class="page-wrapper__title" tag="h1" obj=section />
+
+          <informa-gam-adunit
+            location="taxonomy"
+            position="sponsored_logo"
+            modifiers=["sponsored-logo"]
+            collapse-before-ad-fetch=true
+            with-wrapper=true
+          >
+            <@context section-id=section.id />
+          </informa-gam-adunit>
+
+          <marko-web-website-section-description class="page-wrapper__deck" obj=section />
+        </@section>
+      </marko-web-page-wrapper>
+
+      <marko-web-page-wrapper modifiers=["website-section-contents"]>
+        <@section>
+          <div class="row">
+            <aside class="col-lg-4">
+              Left
+            </aside>
+            <div class="col-lg-8">
+              Right
+            </div>
+          </div>
+        </@section>
+      </marko-web-page-wrapper>
+    </marko-web-resolve-page>
+  </@page>
+  <@below-container>
+    <informa-gam-adunit
+      location="taxonomy"
+      position="hidden"
+    >
+      <@context section-id=id />
+    </informa-gam-adunit>
+  </@below-container>
+</marko-web-website-section-page-layout>

--- a/packages/lazarus-shared/templates/website-section/directory.marko
+++ b/packages/lazarus-shared/templates/website-section/directory.marko
@@ -87,52 +87,6 @@ $ const rootAlias = aliasParts.shift();
               />
             </div>
           </div>
-
-          <!-- <lazarus-skin-page-grid modifiers=["wrap-left-col"]>
-            <@left-col>
-              <lazarus-shared-directory-facets active-alias=alias />
-            </@left-col>
-            <@right-col>
-              <@bottom-row>
-                <marko-web-query|{ nodes }|
-                  name="website-scheduled-content"
-                  params={ sectionId: id, limit: 12, queryFragment }
-                >
-                  <lazarus-skin-page-grid-col modifiers=["full"]>
-                    <lazarus-shared-content-list-flow
-                      nodes=nodes
-                      flush-x=true
-                      flush-y=true
-                      inner-justified=false
-                      modifiers=["feed"]
-                    >
-                      <@node with-dates=false>
-                        <@image width=120 />
-                      </@node>
-                    </lazarus-shared-content-list-flow>
-                  </lazarus-skin-page-grid-col>
-                </marko-web-query>
-
-                <marko-web-load-more
-                  append-to=".page-grid__bottom-row"
-                  expand=500
-                  component-name="lazarus-shared-content-load-more-flow"
-                  component-input={
-                    node: { image: { width: 120 }, withDates: false },
-                    adunit: {
-                      location: "taxonomy",
-                      position: "infinitescroll",
-                      context: { sectionId: section.id },
-                    },
-                  }
-                  fragment-name="content-list"
-                  query-name="website-scheduled-content"
-                  query-params={ sectionId: id, limit: 12, skip: 12 }
-                  page-input={ for: "website-section", id }
-                />
-              </@bottom-row>
-            </@right-col>
-          </lazarus-skin-page-grid> -->
         </@section>
       </marko-web-page-wrapper>
     </marko-web-resolve-page>

--- a/packages/lazarus-shared/theme.scss
+++ b/packages/lazarus-shared/theme.scss
@@ -289,8 +289,13 @@ $theme-content-page-node-full-width: 780px !default;
 
 .node-list {
   $self: &;
+  align-items: normal;
   @include gutter-padding-x-modifier();
   @include gutter-padding-y-modifier();
+
+  &__header {
+    align-self: flex-start;
+  }
 
   &--related-content {
     padding-top: map-get($spacers, block);
@@ -301,13 +306,11 @@ $theme-content-page-node-full-width: 780px !default;
       }
     }
   }
+}
 
-  &--full-width {
-    #{ $self } {
-      &__nodes {
-        width: 100%;
-      }
-    }
+.page {
+  &--load-more {
+    width: 100%;
   }
 }
 

--- a/packages/lazarus-shared/theme.scss
+++ b/packages/lazarus-shared/theme.scss
@@ -301,6 +301,14 @@ $theme-content-page-node-full-width: 780px !default;
       }
     }
   }
+
+  &--full-width {
+    #{ $self } {
+      &__nodes {
+        width: 100%;
+      }
+    }
+  }
 }
 
 .page-grid {

--- a/packages/lazarus-shared/theme.scss
+++ b/packages/lazarus-shared/theme.scss
@@ -42,6 +42,7 @@ $theme-site-header-z-index: 15000;
 @import "../../node_modules/@base-cms/marko-web-gam/scss/fixed-ad-bottom";
 @import "../../node_modules/@base-cms/marko-web-social-sharing/scss/buttons";
 @import "../../node_modules/@base-cms/marko-web-theme-default/skins/lazarus/skin.scss";
+@import "./scss/directory-facets";
 
 $theme-sponsored-content-color: #ee591d !default;
 $theme-content-page-node-full-width: 780px !default;

--- a/packages/lazarus-shared/theme.scss
+++ b/packages/lazarus-shared/theme.scss
@@ -315,6 +315,35 @@ $theme-content-page-node-full-width: 780px !default;
   }
 }
 
+.directory-grid {
+  @include make-row();
+
+  &__left-col {
+    @include make-col-ready();
+    padding-top: $grid-gutter-width;
+    padding-bottom: $grid-gutter-width;
+
+    @include media-breakpoint-up(lg) {
+      @include make-col(4);
+      position: sticky;
+      overflow: scroll;
+      @each $breakpoint, $width in sort-map-by-values($theme-site-header-breakpoints, desc) {
+        @media (max-width: $width) {
+          top: calc(#{calculate-navbar-height-for($breakpoint)});
+          height: calc(100vh - #{calculate-navbar-height-for($breakpoint)});
+        }
+      }
+    }
+  }
+
+  &__right-col {
+    @include make-col-ready();
+    @include media-breakpoint-up(lg) {
+      @include make-col(8);
+    }
+  }
+}
+
 .page-grid {
   &__left-col {
     padding-top: $grid-gutter-width;

--- a/packages/lazarus-shared/theme.scss
+++ b/packages/lazarus-shared/theme.scss
@@ -309,12 +309,6 @@ $theme-content-page-node-full-width: 780px !default;
   }
 }
 
-.page {
-  &--load-more {
-    width: 100%;
-  }
-}
-
 .directory-grid {
   @include make-row();
 


### PR DESCRIPTION
Enabled by default on all sites under the `/directory` route. If a site doesn't have a `directory` section, the page will simply 404 (as expected).

![image](https://user-images.githubusercontent.com/3289485/72533592-09641000-383b-11ea-8e20-3651b173c170.png)
