### PR TITLE
Add custom directory routes

### DIFF
--- a/sites/hydraulicspneumatics.com/index.js
+++ b/sites/hydraulicspneumatics.com/index.js
@@ -1,6 +1,7 @@
 const startServer = require('@endeavor-business-media/lazarus-shared/start-server');
 
-const routes = require('@endeavor-business-media/lazarus-shared/routes');
+const sharedRoutes = require('@endeavor-business-media/lazarus-shared/routes');
+const siteRoutes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
 
@@ -10,5 +11,8 @@ module.exports = startServer({
   rootDir: __dirname,
   coreConfig,
   siteConfig,
-  routes,
+  routes: (app) => {
+    siteRoutes(app);
+    sharedRoutes(app);
+  },
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/hydraulicspneumatics.com/server/routes/index.js
+++ b/sites/hydraulicspneumatics.com/server/routes/index.js
@@ -1,0 +1,22 @@
+const { withWebsiteSection } = require('@base-cms/marko-web/middleware');
+const directory = require('@endeavor-business-media/lazarus-shared/templates/website-section/directory');
+const directoryFragment = require('@endeavor-business-media/lazarus-shared/graphql/fragments/directory-page');
+
+const directoryAliases = [
+  'manufacturer-directory',
+  'distributor-directory',
+];
+
+module.exports = (app) => {
+  directoryAliases.forEach((alias) => {
+    app.get(`/:alias(${alias})`, withWebsiteSection({
+      template: directory,
+      queryFragment: directoryFragment,
+    }));
+
+    app.get(`/:alias(${alias}/[a-z0-9-/]+)`, withWebsiteSection({
+      template: directory,
+      queryFragment: directoryFragment,
+    }));
+  });
+};


### PR DESCRIPTION
Loads the directory landing page on `/manufacturer-directory` and `/distributor-directory` for `hydraulicspneumatics.com` only.

![image](https://user-images.githubusercontent.com/3289485/72539051-5c8e9080-3844-11ea-9b38-d6bf255f73f0.png)

![image](https://user-images.githubusercontent.com/3289485/72539090-687a5280-3844-11ea-8f4b-5f483819d39d.png)
