### PR TITLE
Add "Wildfire" and "Vegetation Management" to site menu

### DIFF
--- a/sites/tdworld.com/config/navigation.js
+++ b/sites/tdworld.com/config/navigation.js
@@ -33,8 +33,9 @@ module.exports = {
         { href: '/substations', label: 'Substations' },
         { href: '/test-and-measurement', label: 'Test and Measurement' },
         { href: '/transmission-reliability', label: 'Transmission Reliability' },
-        { href: '/vegetation-management', label: 'Vegetation Management' },
         { href: '/utility-business', label: 'Utility Business' },
+        { href: '/vegetation-management', label: 'Vegetation Management' },
+        { href: '/wildfire', label: 'Wildfire' },
       ],
     },
     {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/171114225

- Add /wildfire
- Correct alphabetical ordering of navigation by switching Vegetation Management and Utility Business

Current:
<img width="314" alt="Screen Shot 2020-02-06 at 10 03 47 AM" src="https://user-images.githubusercontent.com/6343242/73955376-df958a80-48c8-11ea-9f59-2e0bec7d2151.png">


New:
<img width="313" alt="Screen Shot 2020-02-06 at 10 05 41 AM" src="https://user-images.githubusercontent.com/6343242/73955387-e3c1a800-48c8-11ea-8baa-a6ba9beec6be.png">
