### PR TITLE
Ensure fluid ad unit sizes are handled globally

### DIFF
--- a/packages/informa-gam/components/adunit.marko
+++ b/packages/informa-gam/components/adunit.marko
@@ -21,10 +21,9 @@ $ const {
         $ const attrs = adunitAttrs({ location, position, context, adunit });
         $ const { pos } = targeting;
         $ if (posIncrement && pos) targeting.pos = incrementPos({ pos, inc: posIncrement });
-        $ const size = adunit.fluid ? ["fluid"] : adunit.size;
         <marko-web-gam-define-display-ad
           path=adunit.path
-          size=size
+          size=adunit.size
           size-mapping=adunit.sizeMapping
           targeting=targeting
           oop=adunit.oop

--- a/packages/informa-gam/components/prestitial.marko
+++ b/packages/informa-gam/components/prestitial.marko
@@ -30,7 +30,7 @@ $ const createParams = () => {
           $ const slots = {
             [slotId]: {
               path: adunit.path,
-              size: adunit.fluid ? ["fluid"] : adunit.size,
+              size: adunit.size,
               sizeMapping: adunit.sizeMapping,
               targeting,
             },

--- a/packages/informa-gam/middleware.js
+++ b/packages/informa-gam/middleware.js
@@ -18,7 +18,7 @@ const mapSizes = size => asArray(size).map(({ width, height }) => [width, height
 const buildAdunit = ({ unit, config, globalTargeting }) => ({
   ...unit,
   path: config.createAdUnitPath(unit.path),
-  size: mapSizes(unit.size),
+  size: unit.fluid ? ['fluid'] : mapSizes(unit.size),
   sizeMapping: getAsArray(unit, 'sizeMapping').map(({ viewport: vp, size }) => ({ viewport: [vp.width, vp.height], size: mapSizes(size) })),
   targeting: { ...unit.targeting, ...globalTargeting },
 });


### PR DESCRIPTION
Specifically fixes an issue with the `native_inline { pos: nativekey_13_1 }` positions not firing.