### PR TITLE
Increment the `nativekey_13_[n]` inline ads on content pages

### DIFF
--- a/packages/informa-gam/components/direct-inject-adunit.marko
+++ b/packages/informa-gam/components/direct-inject-adunit.marko
@@ -2,9 +2,13 @@ import { getAsArray, getAsObject } from "@base-cms/object-path";
 import { warn } from "@base-cms/utils";
 import DefineDisplayAd from "@base-cms/marko-web-gam/components/define-display-ad";
 import adunitAttrs from "../utils/create-adunit-attrs";
+import incrementPos from "../utils/increment-pos";
 
 $ const { gam, req } = out.global;
 $ const { testAd } = req.query;
+$ const { posIncrement, incrementor } = input;
+
+$ const posIncrementor = typeof incrementor === "function" ? incrementor : incrementPos;
 
 $ const loadAdunit = async () => {
   const unitInput = getAsObject(input, "adunit");
@@ -20,11 +24,14 @@ $ const loadAdunit = async () => {
 
   // Only allow one adunit to be rendered.
   const adunit = adunits[0];
+  const targeting = { ...adunit.targeting, ...unitInput.targeting, ...(testAd && { testAd }) };
+  const { pos } = targeting;
+  if (posIncrement && pos) targeting.pos = posIncrementor({ pos, inc: posIncrement });
   return {
     path: adunit.path,
     size: adunit.size,
     sizeMapping: adunit.sizeMapping,
-    targeting: ({ ...adunit.targeting, ...unitInput.targeting, ...(testAd && { testAd }) }),
+    targeting,
     collapse: unitInput.collapse,
     collapseBeforeAdFetch: unitInput.collapseBeforeAdFetch,
     id: unitInput.id,

--- a/packages/informa-gam/components/marko.json
+++ b/packages/informa-gam/components/marko.json
@@ -59,7 +59,9 @@
   "<informa-gam-direct-inject-adunit>": {
     "template": "./direct-inject-adunit.marko",
     "<adunit>": {},
-    "@selector": "string"
+    "@selector": "string",
+    "@pos-increment": "number",
+    "@incrementor": "function"
   },
   "<informa-gam-prestitial>": {
     "template": "./prestitial.marko",

--- a/packages/lazarus-shared/components/elements/content-body.marko
+++ b/packages/lazarus-shared/components/elements/content-body.marko
@@ -9,8 +9,19 @@ $ const { type } = content;
 
 $ const adsEnabled = defaultValue(input.adsEnabled, true);
 $ const isPreview = defaultValue(input.isPreview, false);
+$ const pageIndex = defaultValue(input.pageIndex, 0);
 $ const body = isPreview ? getContentPreview({ body: content.body, selector: "p:nth-of-type(1)" }) : content.body;
 $ const bodyId = `content-body-${content.id}`;
+
+$ const incrementNativeInline = ({ pos, inc } = {}) => {
+  if (!pos) return pos;
+  const pattern = /(nativekey_13_)(\d{1,})/;
+  const matches = pattern.exec(pos);
+  if (!matches || !matches[2]) return pos;
+  const n = inc + parseInt(matches[2], 10);
+  const newPos = pos.replace(pattern, `$1${n <= 10 ? n : 10}`);
+  return newPos;
+};
 
 <default-theme-page-contents|{ blockName }|>
   <default-theme-content-contact-details obj=content />
@@ -49,7 +60,11 @@ $ const bodyId = `content-body-${content.id}`;
 
 
       <!-- inject native ad after second paragraph -->
-      <informa-gam-direct-inject-adunit selector=`#${bodyId} > p:nth-of-type(2)`>
+      <informa-gam-direct-inject-adunit
+        selector=`#${bodyId} > p:nth-of-type(2)`
+        pos-increment=pageIndex
+        incrementor=incrementNativeInline
+      >
         <@adunit location=adLocation(type) position="native_inline" modifiers=["body-inline"]>
           <@context content-id=content.id />
         </@adunit>

--- a/packages/lazarus-shared/components/elements/marko.json
+++ b/packages/lazarus-shared/components/elements/marko.json
@@ -3,7 +3,8 @@
     "template": "./content-body.marko",
     "@node": "object",
     "@is-preview": "boolean",
-    "@ads-enabled": "boolean"
+    "@ads-enabled": "boolean",
+    "@page-index": "number"
   },
   "<lazarus-shared-slideshow-button-element>": {
     "template": "./slideshow-button.marko",

--- a/packages/lazarus-shared/components/flows/content-page-load-more.marko
+++ b/packages/lazarus-shared/components/flows/content-page-load-more.marko
@@ -22,5 +22,5 @@ $ const { pageNumber } = input;
       <@context content-id=content.id />
     </informa-gam-adunit>
   </lazarus-skin-page-grid-col>
-  <lazarus-shared-content-page-node node=nodes[0] />
+  <lazarus-shared-content-page-node node=nodes[0] page-number=pageNumber />
 </if>

--- a/packages/lazarus-shared/components/nodes/content-page.marko
+++ b/packages/lazarus-shared/components/nodes/content-page.marko
@@ -8,6 +8,7 @@ $ const primarySection = getAsObject(content, "primarySection");
 $ const requiresRegistration = get(content, "userRegistration.isRequired");
 
 $ const fullWidth = defaultValue(input.fullWidth, false);
+$ const pageIndex = defaultValue(input.pageNumber, 0);
 $ const modifiers = [];
 $ const imgInput = {};
 $ if (fullWidth) {
@@ -32,6 +33,7 @@ $ if (fullWidth) {
           node=content
           is-preview=true
           ads-enabled=input.adsEnabled
+          page-index=pageIndex
         />
         <lazarus-shared-content-gate
           is-logged-in=context.isLoggedIn
@@ -44,6 +46,7 @@ $ if (fullWidth) {
         <lazarus-shared-content-body-element
           node=content
           ads-enabled=input.adsEnabled
+          page-index=pageIndex
         />
       </else>
     </marko-web-identity-x-access>

--- a/packages/lazarus-shared/components/nodes/marko.json
+++ b/packages/lazarus-shared/components/nodes/marko.json
@@ -37,7 +37,9 @@
     "template": "./content-page.marko",
     "@node": "object",
     "@ads-enabled": "boolean",
-    "@full-width": "boolean"
+    "@full-width": "boolean",
+    "@page-number": "number"
+
   },
   "<lazarus-shared-contact-us-list-node>": {
     "template": "./contact-us-list.marko",


### PR DESCRIPTION
Previously, all additional content page calls to this ad unit was using `nativekey_13_1` for the `pos` value. Now, as each new content page is loaded via infinite scroll, the final number will be incremented by one, up to a max of ten.

- `nativekey_13_1`
- `nativekey_13_2`
- ...
- `nativekey_13_10`