### PR TITLE
Disable GraphQL cache when requesting ad units

### DIFF
--- a/packages/informa-gam/middleware.js
+++ b/packages/informa-gam/middleware.js
@@ -5,13 +5,16 @@ const { ApolloClient } = require('apollo-client');
 const { InMemoryCache } = require('apollo-cache-inmemory');
 const { createHttpLink } = require('apollo-link-http');
 const { asObject, asArray } = require('@base-cms/utils');
-const { dasherize } = require('@base-cms/inflector');
+const { dasherize, camelize } = require('@base-cms/inflector');
 const { getAsArray } = require('@base-cms/object-path');
 const GAMConfiguration = require('@base-cms/marko-web-gam/config');
 
 const { GAM_SERVICE_URI, TENANT_KEY } = require('./env');
 
-const createCacheKey = (location, context) => `${location}|${JSON.stringify(context || {})}`;
+const camelizeObj = obj => Object.keys(obj)
+  .reduce((o, key) => ({ ...o, [camelize(key)]: obj[key] }), {});
+
+const createCacheKey = (location, context) => `${location}|${JSON.stringify(camelizeObj(context || {}))}`;
 
 const mapSizes = size => asArray(size).map(({ width, height }) => [width, height]);
 
@@ -75,7 +78,12 @@ module.exports = ({ accountId, basePath } = {}) => (req, res, next) => {
     if (!cache.has(key)) {
       const input = { location };
       const headers = contextHeaders(context);
-      const promise = apollo.query({ query, variables: { input }, context: { headers } })
+      const promise = apollo.query({
+        query,
+        variables: { input },
+        context: { headers },
+        fetchPolicy: 'no-cache',
+      })
         .then(({ data }) => data.locationAdunits)
         .then(({ targeting: globalTargeting, adunits: units }) => units.reduce((map, unit) => {
           const { position } = unit;


### PR DESCRIPTION
The context values are not being taken into account when the GraphQL client is caching the ad unit results. As such, when two content items are loaded within the same request, the second item will receive the targeting values of the first. This sets the GraphQL fetch policy to `no-cache` to prevent this.

In addition, some (internal) cache keys were being generated with camel and kebab case object properties. This corrects that by camelizing all context keys.