### PR TITLE
Replace Trump and Manufacturing navigation item with IndustryWeek at 50 

### DIFF
--- a/sites/industryweek.com/config/navigation.js
+++ b/sites/industryweek.com/config/navigation.js
@@ -35,7 +35,7 @@ module.exports = {
         { href: '/resources/industryweek-50-best-us-manufacturers', label: 'IW US 50 Best' },
         { href: '/resources/industryweek-us-500', label: 'IW US 500' },
         { href: '/supply-chain-initiative', label: 'Supply Chain Initiative' },
-        { href: '/trump-and-manufacturing', label: 'Trump and Manufacturing' },
+        { href: '/industry-week-at-50', label: 'IndustryWeek at 50' },
         { href: '/resources/iw-best-practices-reports', label: 'IW Best Practices Reports' },
         { href: '/webinars', label: 'Webinars' },
         { href: '/white-papers', label: 'White Papers' },


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/171507360

Remove “Trump and Manufacturing” from the hamburger menu.

Add "IndustryWeek at 50" to the hamburger menu (same location as Trump section)