### PR TITLE
Remove Design Learning Center from hamburger nav

### DIFF
--- a/sites/electronicdesign.com/config/navigation.js
+++ b/sites/electronicdesign.com/config/navigation.js
@@ -32,7 +32,6 @@ module.exports = {
     {
       modifiers: ['secondary'],
       items: [
-        { href: '/design-learning-center', label: 'Design & Learning Center' },
         { href: 'http://sourceesb.com/', label: 'Find Parts', target: '_blank' },
         { href: '/magazine-digital-archive', label: 'Digital Archive' },
         { href: '/learning-resources/webcasts', label: 'Webinars' },


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/171508263