### PR TITLE
Proxy Eloqua Form API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,9 @@ x-env-defaults: &env
   IDENTITYX_GRAPHQL_URI: ${IDENTITYX_GRAPHQL_URI-https://identity-x.io/graphql}
   NEW_RELIC_ENABLED: ${NEW_RELIC_ENABLED-0}
   NEW_RELIC_LICENSE_KEY: ${NEW_RELIC_LICENSE_KEY-(unset)}
+  ELOQUA_SITE_NAME: ${ELOQUA_SITE_NAME-(unset)}
+  ELOQUA_USER: ${ELOQUA_USER-(unset)}
+  ELOQUA_PASSWORD: ${ELOQUA_PASSWORD-(unset)}
   NODE_ENV: development
   # @todo the recaptcha values should be removed (?) once contact-us is moved to core.
   RECAPTCHA_SECRET_KEY: ${RECAPTCHA_SECRET_KEY-(unset)}

--- a/packages/lazarus-shared/routes/eloqua.js
+++ b/packages/lazarus-shared/routes/eloqua.js
@@ -9,7 +9,7 @@ module.exports = (app) => {
       {
         headers: {
           'content-type': 'application/json',
-          Authorization: `Basic ${auth}`,
+          authorization: `basic ${auth}`,
         },
       },
     );

--- a/packages/lazarus-shared/routes/eloqua.js
+++ b/packages/lazarus-shared/routes/eloqua.js
@@ -1,7 +1,8 @@
 const fetch = require('node-fetch');
+const asyncRoute = require('@base-cms/utils/src/async-route.js');
 
 module.exports = (app) => {
-  app.get('/__eloqua/form/:formId', async (req, res) => {
+  app.get('/__eloqua/form/:formId', asyncRoute(async (req, res) => {
     const auth = Buffer.from(`${process.env.ELOQUA_SITE_NAME}\\${process.env.ELOQUA_USER}:${process.env.ELOQUA_PASSWORD}`).toString('base64');
     const data = await fetch(
       `https://secure.p01.eloqua.com/api/REST/2.0/assets/form/${req.params.formId}`,
@@ -13,5 +14,5 @@ module.exports = (app) => {
       },
     ).then(r => r.json());
     res.json({ html: data.html });
-  });
+  }));
 };

--- a/packages/lazarus-shared/routes/eloqua.js
+++ b/packages/lazarus-shared/routes/eloqua.js
@@ -1,0 +1,17 @@
+const fetch = require('node-fetch');
+
+module.exports = (app) => {
+  app.get('/__eloqua/form/:formId', async (req, res) => {
+    const auth = Buffer.from(`${process.env.ELOQUA_SITE_NAME}\\${process.env.ELOQUA_USER}:${process.env.ELOQUA_PASSWORD}`).toString('base64');
+    const data = await fetch(
+      `https://secure.p01.eloqua.com/api/REST/2.0/assets/form/${req.params.formId}`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Basic ${auth}`,
+        },
+      },
+    ).then(r => r.json());
+    res.json({ html: data.html });
+  });
+};

--- a/packages/lazarus-shared/routes/eloqua.js
+++ b/packages/lazarus-shared/routes/eloqua.js
@@ -1,18 +1,19 @@
 const fetch = require('node-fetch');
-const asyncRoute = require('@base-cms/utils/src/async-route.js');
+const asyncRoute = require('@base-cms/utils/src/async-route');
 
 module.exports = (app) => {
   app.get('/__eloqua/form/:formId', asyncRoute(async (req, res) => {
     const auth = Buffer.from(`${process.env.ELOQUA_SITE_NAME}\\${process.env.ELOQUA_USER}:${process.env.ELOQUA_PASSWORD}`).toString('base64');
-    const data = await fetch(
+    const response = await fetch(
       `https://secure.p01.eloqua.com/api/REST/2.0/assets/form/${req.params.formId}`,
       {
         headers: {
-          'Content-Type': 'application/json',
+          'content-type': 'application/json',
           Authorization: `Basic ${auth}`,
         },
       },
-    ).then(r => r.json());
-    res.json({ html: data.html });
+    );
+    const json = await response.json();
+    res.json({ html: json.html });
   }));
 };

--- a/packages/lazarus-shared/routes/index.js
+++ b/packages/lazarus-shared/routes/index.js
@@ -6,6 +6,7 @@ const subscribe = require('./subscribe');
 const digitalEdition = require('./digital-edition');
 const websiteSections = require('./website-section');
 const user = require('./user');
+const eloqua = require('./eloqua');
 
 module.exports = (app) => {
   // User (IdentityX)
@@ -31,4 +32,7 @@ module.exports = (app) => {
 
   // Website Sections
   websiteSections(app);
+
+  // Get Eloqua Form
+  eloqua(app);
 };


### PR DESCRIPTION
Eloqua API doesn't allow cross origin requests. This allows us to hit their API to get the form HTML.

<img width="754" alt="Screen Shot 2020-03-17 at 11 53 16 AM" src="https://user-images.githubusercontent.com/3812216/76882512-c4635680-6848-11ea-85fa-656b8a4b18f1.png">
