### PR TITLE
Add COVID-19 to menu navigation

### DIFF
--- a/sites/fleetowner.com/config/navigation.js
+++ b/sites/fleetowner.com/config/navigation.js
@@ -19,6 +19,7 @@ module.exports = {
   menu: [
     {
       items: [
+        { href: '/covid-19-coverage', label: 'COVID-19 Coverage 2020' },
         { href: '/news', label: 'News' },
         { href: '/equipment', label: 'Equipment' },
         { href: '/safety', label: 'Safety' },

--- a/sites/trucker.com/config/navigation.js
+++ b/sites/trucker.com/config/navigation.js
@@ -19,6 +19,7 @@ module.exports = {
   menu: [
     {
       items: [
+        { href: '/covid-19-coverage', label: 'COVID-19 Coverage 2020' },
         { href: '/news', label: 'News' },
         { href: '/equipment', label: 'Equipment' },
         { href: '/business', label: 'Business' },


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/171867587

Added /covid-19-coverage links to the navs for Trucker and Fleetowner

![Screen Shot 2020-03-18 at 6 48 20 PM](https://user-images.githubusercontent.com/6343242/77017689-14c1dd80-6949-11ea-9f91-3637ad98c51e.png)
![Screen Shot 2020-03-18 at 6 45 42 PM](https://user-images.githubusercontent.com/6343242/77017691-155a7400-6949-11ea-80de-946f0a8de1e1.png)
