### PR TITLE
Updated Newrelic app_name to match repo name

### DIFF
--- a/packages/lazarus-shared/newrelic.js
+++ b/packages/lazarus-shared/newrelic.js
@@ -8,7 +8,7 @@ exports.config = {
   /**
    * Array of application names.
    */
-  app_name: ['base-cms-websites/endeavor-business-media'],
+  app_name: ['base-cms-websites/informa-business-intelligence'],
   /**
    * Your New Relic license key.
    */


### PR DESCRIPTION
Split out app_name in Newrelic to help get more granular data. It also makes it match the rest of the repos structure. 