### PR TITLE
Add event links to secondary navs

### DIFF
--- a/sites/americanmachinist.com/config/navigation.js
+++ b/sites/americanmachinist.com/config/navigation.js
@@ -32,6 +32,8 @@ module.exports = {
       modifiers: ['secondary'],
       items: [
         { href: '/webinars', label: 'Webinars' },
+        { href: 'https://www.mfgtechshow.com/', label: 'Manufacturing & Technology', target: '_blank' },
+        { href: 'https://www.safetyleadershipconference.com/', label: 'Safety Leadership Conference', target: '_blank' },
         { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewsletter Subscription', target: '_blank' },
         { href: '/directory', label: 'Buyers’ Guide' },
         { href: '/page/contact-us', label: 'Contact Us' },

--- a/sites/ehstoday.com/config/navigation.js
+++ b/sites/ehstoday.com/config/navigation.js
@@ -35,13 +35,14 @@ module.exports = {
     {
       modifiers: ['secondary'],
       items: [
-        { href: 'https://www.safetyleadershipconference.com/', label: 'Safety Leadership Conference' },
         { href: '/americas-safest-companies-awards', label: 'ASC Awards' },
         { href: '/news', label: 'Latest Headlines' },
         { href: '/ghs', label: 'GHS' },
         { href: '/arc-flash', label: 'Arc Flash' },
         { href: '/webinars', label: 'Webinars' },
         { href: '/white-papers-and-case-studies', label: 'White Papers' },
+        { href: 'https://www.mfgtechshow.com/', label: 'Manufacturing & Technology', target: '_blank' },
+        { href: 'https://www.safetyleadershipconference.com/', label: 'Safety Leadership Conference', target: '_blank' },
         { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
         { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewsletter Subscription', target: '_blank' },
         { href: '/page/contact-us', label: 'Contact Us' },

--- a/sites/industryweek.com/config/navigation.js
+++ b/sites/industryweek.com/config/navigation.js
@@ -39,6 +39,8 @@ module.exports = {
         { href: '/resources/iw-best-practices-reports', label: 'IW Best Practices Reports' },
         { href: '/webinars', label: 'Webinars' },
         { href: '/white-papers', label: 'White Papers' },
+        { href: 'https://www.mfgtechshow.com/', label: 'Manufacturing & Technology', target: '_blank' },
+        { href: 'https://www.safetyleadershipconference.com/', label: 'Safety Leadership Conference', target: '_blank' },
         { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
         { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewsletter Subscription', target: '_blank' },
         { href: '/page/contact-us', label: 'Contact Us' },

--- a/sites/machinedesign.com/config/navigation.js
+++ b/sites/machinedesign.com/config/navigation.js
@@ -39,6 +39,8 @@ module.exports = {
         { href: 'http://directory.newequipment.com/', label: 'Equipment Product Directory' },
         { href: 'http://www.industryweek.com/', label: 'The Business of Manufacturing' },
         { href: 'http://www.hydraulicspneumatics.com/', label: 'Hydraulics & Pneumatics' },
+        { href: 'https://www.mfgtechshow.com/', label: 'Manufacturing & Technology', target: '_blank' },
+        { href: 'https://www.safetyleadershipconference.com/', label: 'Safety Leadership Conference', target: '_blank' },
         { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
         { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewsletter Subscription', target: '_blank' },
         { href: '/learning-resources/webinars', label: 'Webinars' },

--- a/sites/mhlnews.com/config/navigation.js
+++ b/sites/mhlnews.com/config/navigation.js
@@ -36,6 +36,8 @@ module.exports = {
         { href: '/new-products', label: 'Latest Product & Services' },
         { href: '/directory', label: 'Buyers Guide' },
         { href: '/webinars', label: 'Webinars' },
+        { href: 'https://www.mfgtechshow.com/', label: 'Manufacturing & Technology', target: '_blank' },
+        { href: 'https://www.safetyleadershipconference.com/', label: 'Safety Leadership Conference', target: '_blank' },
         { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewsletter Subscription', target: '_blank' },
         { href: '/page/contact-us', label: 'Contact Us' },
         { href: 'https://manufacturing.endeavorb2b.com/mhl', label: 'Advertise', target: '_blank' },

--- a/sites/newequipment.com/config/navigation.js
+++ b/sites/newequipment.com/config/navigation.js
@@ -31,6 +31,8 @@ module.exports = {
       modifiers: ['secondary'],
       items: [
         { href: 'http://directory.newequipment.com/', label: 'NED Directory' },
+        { href: 'https://www.mfgtechshow.com/', label: 'Manufacturing & Technology', target: '_blank' },
+        { href: 'https://www.safetyleadershipconference.com/', label: 'Safety Leadership Conference', target: '_blank' },
         { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
         { href: dragonForms.getFormUrl('newsletterSignup'), label: 'eNewsletter Subscription', target: '_blank' },
         { href: '/page/about-us', label: 'About Us' },


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/172213040

**From request:** 
The event marketing manager for the Manufacturing sites would like to showcase these 2 events via hamburger navigation links:

Manufacturing & Technology (https://www.mfgtechshow.com)
Safety Leadership Conference ( https://www.safetyleadershipconference.com​ )

This hamburger nav update would be for the following sites:

IndustryWeek
NED
MH&L
Machine Design
American Machinist
EHS Today

So above the "Magazine Subscription" link across the hamburger navs on the Manufacturing sites, we would add a link for "Manufacturing & Technology" and "Safety Leadership Conference" (and have them link off to the URLs listed above).