### PR TITLE
Add Covid 19 link to secondary nav

### DIFF
--- a/sites/ehstoday.com/config/navigation.js
+++ b/sites/ehstoday.com/config/navigation.js
@@ -35,6 +35,7 @@ module.exports = {
     {
       modifiers: ['secondary'],
       items: [
+        { href: '/covid19', label: 'COVID-19 Crisis' },
         { href: '/americas-safest-companies-awards', label: 'ASC Awards' },
         { href: '/news', label: 'Latest Headlines' },
         { href: '/ghs', label: 'GHS' },

--- a/sites/mhlnews.com/config/navigation.js
+++ b/sites/mhlnews.com/config/navigation.js
@@ -31,6 +31,7 @@ module.exports = {
     {
       modifiers: ['secondary'],
       items: [
+        { href: '/covid19', label: 'COVID-19 Crisis' },
         { href: '/drones-and-autonomous-vehicles', label: 'Drones & Autonomous Vehicles' },
         { href: '/trump-supply-chain', label: 'Trump & the Supply Chain' },
         { href: '/new-products', label: 'Latest Product & Services' },


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/172314282

New:
<img width="362" alt="Screen Shot 2020-04-16 at 11 43 45 AM" src="https://user-images.githubusercontent.com/6343242/79477018-aa4b9e00-7fd7-11ea-80eb-e94d7fcfdf85.png">
<img width="386" alt="Screen Shot 2020-04-16 at 11 41 10 AM" src="https://user-images.githubusercontent.com/6343242/79477020-aae43480-7fd7-11ea-9fe0-016e75720d09.png">
