### PR TITLE
Add BlueConic meta tags based off content page

### DIFF
--- a/packages/lazarus-shared/components/blocks/content-meta-data-tags.marko
+++ b/packages/lazarus-shared/components/blocks/content-meta-data-tags.marko
@@ -1,0 +1,25 @@
+import { asObject } from '@base-cms/utils';
+
+$ const name = input.name || 'dataLayer';
+$ const obj = asObject(input.data);
+$ let createdBy = (obj.created_by.firstName);
+$ createdBy = (!obj.created_by.lastName) ? Created_by : createdBy += obj.created_by.lastName;
+$ createdBy = (createdBy) ? createdBy : obj.created_by.username;
+$ const tags = obj.taxonomy.map((tag) => tag.name).join(',');
+$ const authors = obj.authors.map((tag) => tag.name).join(',');
+$ const secondarySections = obj.section_hierarchy.filter(section => section.id !== obj.section.id).map((tag) => tag.name).join(',');
+
+<meta name="page_type" content=obj.page_type>
+<meta name="content" content=obj.content.type>
+<meta name="canonical_path" content=obj.canonical_path>
+<meta name="Created_by" content=obj.created_by.username>
+<if(obj.company.name !== 'undefined')>
+  <meta name="Company" content="">
+</if>
+<meta name="section" content=obj.section.name>
+<meta name="primary_section" content=obj.section.name>
+<if(secondarySections)>
+  <meta name="secondary_sections" content=secondarySections>
+</if>
+<meta name="authors" content=authors>
+<meta name="tags" content=tags>

--- a/packages/lazarus-shared/components/blocks/content-meta-data.marko
+++ b/packages/lazarus-shared/components/blocks/content-meta-data.marko
@@ -1,0 +1,70 @@
+import gql from "graphql-tag";
+import { isFunction, warn } from "@base-cms/utils";
+import { contentBuilder } from "@base-cms/marko-web-gtm/context";
+
+$ const { req } = out.global;
+$ const { id } = input;
+$ const builder = isFunction(input.builder) ? input.builder : contentBuilder;
+
+$ const queryFragment = input.queryFragment || gql`
+fragment ContentContextFragment on Content {
+  id
+  type
+  name
+  siteContext {
+    path
+  }
+  published
+  createdBy {
+    id
+    username
+    firstName
+    lastName
+  }
+  company {
+    id
+    name
+  }
+  primarySection {
+    id
+    name
+    alias
+    fullName
+    hierarchy {
+      id
+      name
+      alias
+    }
+  }
+  taxonomy {
+    edges {
+      node {
+        id
+        type
+        name
+        fullName
+      }
+    }
+  }
+  ... on Authorable {
+    authors {
+      edges {
+        node {
+          id
+          name
+        }
+      }
+    }
+  }
+}
+`;
+
+<if(id)>
+  <marko-web-query|{ node }| name="content" params={ id, queryFragment }>
+    $ const context = builder({ type: "content", obj: node, req });
+    <${input.renderBody} context=context />
+  </marko-web-query>
+</if>
+<else>
+  $ warn('Unable to create GTM content context: no content id was provided.');
+</else>

--- a/packages/lazarus-shared/components/blocks/marko.json
+++ b/packages/lazarus-shared/components/blocks/marko.json
@@ -13,6 +13,20 @@
       "<context>": {}
     }
   },
+  "<lazarus-shared-content-meta-data-context>": {
+    "template": "./content-meta-data.marko",
+    "@id": "number",
+    "@builder": "function",
+    "@query-fragment": "expression"
+  },
+  "<lazarus-shared-content-meta-data-tags>": {
+    "template": "./content-meta-data-tags.marko",
+    "@name": {
+      "type": "string",
+      "default-value": "dataLayer"
+    },
+    "@data": "object"
+  },
   "<lazarus-shared-newsletter-signup-block>": {
     "template": "./omeda-newsletter-signup.marko"
   }

--- a/packages/lazarus-shared/templates/content/full-width.marko
+++ b/packages/lazarus-shared/templates/content/full-width.marko
@@ -4,8 +4,12 @@ $ const { id, type, pageNode } = data;
 <marko-web-content-page-layout id=id type=type>
   <@head>
     <marko-web-gtm-content-context|{ context }| id=id>
+      <!-- $ console.log(context); -->
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
+    <lazarus-shared-content-meta-data-context|{ context }| id=id>
+      <lazarus-shared-content-meta-data-tags data=context />
+    </lazarus-shared-content-meta-data-context>
   </@head>
   <@page>
     <marko-web-resolve-page|{ data: content }| node=pageNode>

--- a/packages/lazarus-shared/templates/content/index.marko
+++ b/packages/lazarus-shared/templates/content/index.marko
@@ -8,6 +8,9 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
+    <lazarus-shared-content-meta-data-context|{ context }| id=id>
+      <lazarus-shared-content-meta-data-tags data=context />
+    </lazarus-shared-content-meta-data-context>
   </@head>
   <@page>
 

--- a/packages/lazarus-shared/templates/content/print.marko
+++ b/packages/lazarus-shared/templates/content/print.marko
@@ -23,6 +23,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact", "company"].includ
       <marko-web-gtm-push data=ctx />
     </marko-web-gtm-content-context>
     <marko-web-gtm-start />
+    <lazarus-shared-content-meta-data-context|{ context }| id=id>
+      <lazarus-shared-content-meta-data-tags data=context />
+    </lazarus-shared-content-meta-data-context>
   </@head>
   <@above-container>
     <div class="container p-5 bg-white">

--- a/packages/lazarus-shared/templates/content/slideshow.marko
+++ b/packages/lazarus-shared/templates/content/slideshow.marko
@@ -18,6 +18,9 @@ $ const getGalleryImages = (resolved) => {
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
+    <lazarus-shared-content-meta-data-context|{ context }| id=id>
+      <lazarus-shared-content-meta-data-tags data=context />
+    </lazarus-shared-content-meta-data-context>
   </@head>
   <@page>
     <marko-web-gam-refresh-ad on="gallery-slideshow-slide-change" slot-id="gpt-slideshow-top-banner" />


### PR DESCRIPTION
 - Added context meta data to content landing pages based of  content context
 - This is based off of the ticket info in https://www.pivotaltracker.com/n/projects/2431161/stories/172506788 not sure if it is tracking right or not but based it off of the google doc
  — page_type
  — content
 — canonical_path
 — Created_by
 — Company
 — section
 — primary_section
 — secondary_sections
 — authors
 — tags

Google Doc requirements: https://docs.google.com/document/d/1oHXIA9hf5n5L2-TkbkxY9H2PAUZrBPmLqISAV0Ds_s0/edit

Example: https://www.electronicdesign.com/technologies/embedded-revolution/article/21129812/qualcomm-upgrades-bluetooth-audio-chips-to-take-on-apples-airpods
```

<meta name="page_type" content="content">
<meta name="content" content="article">
<meta name="canonical_path" content="/technologies/embedded-revolution/article/21129812/qualcomm-upgrades-bluetooth-audio-chips-to-take-on-apples-airpods">
<meta name="Created_by" content="jmorra">
<meta name="Company" content="">
<meta name="section" content="Embedded Revolution">
<meta name="primary_section" content="Embedded Revolution">
<meta name="secondary_sections" content="Technologies">
<meta name="authors" content="James Morra">
<meta name="tags" content="Buyer's Journey,Consideration,Awareness,Discovery,General Article,Article,News,Bluetooth Audio SoCs,Wireless Headphones,Bluetooth Earbuds">
```

Fingers crossed!