### PR TITLE
Add support for comments

### DIFF
--- a/packages/lazarus-shared/components/elements/content-body.marko
+++ b/packages/lazarus-shared/components/elements/content-body.marko
@@ -13,6 +13,8 @@ $ const pageIndex = defaultValue(input.pageIndex, 0);
 $ const body = isPreview ? getContentPreview({ body: content.body, selector: "p:nth-of-type(1)" }) : content.body;
 $ const bodyId = `content-body-${content.id}`;
 
+$ const displayComments = ["contact", "document", "whitepaper", "product", "company"].includes(type) ? false : true;
+
 $ const incrementNativeInline = ({ pos, inc } = {}) => {
   if (!pos) return pos;
   const pattern = /(nativekey_13_)(\d{1,})/;
@@ -121,5 +123,8 @@ $ const incrementNativeInline = ({ pos, inc } = {}) => {
         target="_blank"
       />
     </if>
+    <lazarus-shared-content-comments should-display=displayComments>
+      <@content id=content.id name=content.name teaser=content.teaser url=content.siteContext.canonicalUrl />
+    </lazarus-shared-content-comments>
   </else>
 </default-theme-page-contents>

--- a/packages/lazarus-shared/components/elements/content-comments.marko
+++ b/packages/lazarus-shared/components/elements/content-comments.marko
@@ -1,0 +1,18 @@
+import { getAsObject } from "@base-cms/object-path";
+import defaultValue from "@base-cms/marko-core/utils/default-value";
+
+$ const { req, site } = out.global;
+$ const { identityX } = req;
+$ const isEnabled = Boolean(identityX && site.get('identityX.comments.enabled'));
+$ const shouldDisplay = defaultValue(input.shouldDisplay, true);
+
+$ const content = getAsObject(input, "content");
+
+<if(shouldDisplay && isEnabled)>
+  <marko-web-identity-x-comment-stream
+    identifier=content.id
+    title=content.name
+    description=content.teaser
+    url=content.url
+  />
+</if>

--- a/packages/lazarus-shared/components/elements/marko.json
+++ b/packages/lazarus-shared/components/elements/marko.json
@@ -10,5 +10,15 @@
     "template": "./slideshow-button.marko",
     "@block-name": "string",
     "@path": "string"
+  },
+  "<lazarus-shared-content-comments>": {
+    "template": "./content-comments.marko",
+    "<content>": {
+      "@id": "number",
+      "@name": "string",
+      "@teaser": "string",
+      "@url": "string"
+    },
+    "@should-display": "boolean"
   }
 }

--- a/packages/lazarus-shared/identity-x.js
+++ b/packages/lazarus-shared/identity-x.js
@@ -1,16 +1,16 @@
 const IdentityX = require('@base-cms/marko-web-identity-x');
 const IdentityXConfig = require('@base-cms/marko-web-identity-x/config');
-const authenticate = require('../templates/user/authenticate');
-const login = require('../templates/user/login');
-const logout = require('../templates/user/logout');
-const profile = require('../templates/user/profile');
-const register = require('../templates/user/register');
+const { getAsObject, get } = require('@base-cms/object-path');
+const authenticate = require('./templates/user/authenticate');
+const login = require('./templates/user/login');
+const logout = require('./templates/user/logout');
+const profile = require('./templates/user/profile');
+const register = require('./templates/user/register');
 
 const { isArray } = Array;
 
-module.exports = (app) => {
-  const { site } = app.locals;
-  const { appId, enabled, options } = site.getAsObject('identityX');
+module.exports = (app, startOptions) => {
+  const { appId, enabled, options } = getAsObject(startOptions, 'siteConfig.identityX');
   if (appId && enabled) {
     const config = new IdentityXConfig({
       requiredServerFields: ['givenName', 'familyName', 'countryCode'],
@@ -27,7 +27,7 @@ module.exports = (app) => {
       { href: config.getEndpointFor('register'), label: 'Register', when: 'logged-out' },
     ];
 
-    const navItems = site.get('navigation.tertiary.items');
+    const navItems = get(startOptions, 'siteConfig.navigation.tertiary.items');
     if (isArray(navItems)) navItems.unshift(...navConfig);
 
     app.get(config.getEndpointFor('authenticate'), (_, res) => { res.marko(authenticate); });

--- a/packages/lazarus-shared/routes/index.js
+++ b/packages/lazarus-shared/routes/index.js
@@ -5,12 +5,8 @@ const search = require('./search');
 const subscribe = require('./subscribe');
 const digitalEdition = require('./digital-edition');
 const websiteSections = require('./website-section');
-const user = require('./user');
 
 module.exports = (app) => {
-  // User (IdentityX)
-  user(app);
-
   // Homepage
   home(app);
 

--- a/packages/lazarus-shared/scss/_identity-x.scss
+++ b/packages/lazarus-shared/scss/_identity-x.scss
@@ -1,0 +1,95 @@
+.idx-comment-stream {
+  @include theme-card();
+  margin-top: map-get($spacers, block);
+  background-color: #f6f6f6;
+
+  &__header {
+    @include theme-card-header();
+    @include border-top-radius($theme-item-list-border-radius);
+    line-height: get-line-height($theme-card-header-font-size, 26px);
+    letter-spacing: normal;
+    background-color: #fff;
+  }
+
+  &__body {
+    padding: $marko-web-node-list-padding;
+    padding-bottom: 0;
+  }
+
+  &__login-form {
+    margin-top: -1.75rem;
+    margin-bottom: map-get($spacers, block);
+  }
+
+  &__login-message {
+    font-weight: $font-weight-bold;
+  }
+
+  &__close-form-wrapper {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+  }
+
+  &__close-form {
+    padding: .25rem;
+    margin-left: auto;
+    font-size: 1.75rem;
+    font-weight: $font-weight-bold;
+    line-height: 1;
+    color: #000;
+    text-shadow: 0 1px 0 #fff;
+    background-color: transparent;
+    border: 0;
+    opacity: .5;
+
+    &:hover,
+    &:focus {
+      opacity: .75;
+    }
+  }
+
+  &__loading,
+  &__error {
+    padding: $marko-web-node-list-padding;
+  }
+
+  &__create-post {
+    padding-bottom: $marko-web-node-list-padding;
+  }
+
+  &__no-posts {
+    @include marko-web-node-list-border($property: border-top);
+    padding: $marko-web-node-list-padding;
+  }
+
+  &__post {
+    @include marko-web-node-list-border($property: border-bottom);
+    padding: $marko-web-node-list-padding;
+    &:first-child {
+      @include marko-web-node-list-border($property: border-top);
+    }
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
+  &__archived {
+    font-weight: $font-weight-bold;
+  }
+}
+
+.idx-comment-post {
+  &__header {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: .375rem;
+    font-size: 14px;
+    color: rgba(0, 0, 0, .54);
+  }
+
+  &__flagged {
+    margin-bottom: .375rem;
+    font-weight: $font-weight-bold;
+  }
+}

--- a/packages/lazarus-shared/start-server.js
+++ b/packages/lazarus-shared/start-server.js
@@ -4,6 +4,7 @@ const { get, set } = require('@base-cms/object-path');
 const gam = require('@endeavor-business-media/informa-gam/middleware');
 const cleanResponse = require('@base-cms/marko-core/middleware/clean-marko-response');
 
+const identityX = require('./identity-x');
 const document = require('./components/document');
 const components = require('./components');
 const fragments = require('./fragments');
@@ -26,6 +27,8 @@ module.exports = (options = {}) => {
         set(app.locals, 'markoCoreDate.format', 'MMM DD, YYYY');
         next();
       });
+      // Setup IdentityX
+      identityX(app, options);
       // Clean all response bodies.
       app.use(cleanResponse());
     },

--- a/packages/lazarus-shared/theme.scss
+++ b/packages/lazarus-shared/theme.scss
@@ -43,6 +43,7 @@ $theme-site-header-z-index: 15000;
 @import "../../node_modules/@base-cms/marko-web-social-sharing/scss/buttons";
 @import "../../node_modules/@base-cms/marko-web-theme-default/skins/lazarus/skin.scss";
 @import "./scss/directory-facets";
+@import "./scss/identity-x";
 
 $theme-sponsored-content-color: #ee591d !default;
 $theme-content-page-node-full-width: 780px !default;

--- a/sites/industryweek.com/config/site.js
+++ b/sites/industryweek.com/config/site.js
@@ -8,6 +8,7 @@ module.exports = {
   identityX: {
     enabled: true,
     appId: '5df0e8f105aa56e67d43fc37',
+    comments: { enabled: true },
   },
   homePageSections: [
     { alias: 'operations', name: 'Operations' },


### PR DESCRIPTION
Currently, comments are only enabled for Industry Week.

The IdentityX middleware was moved into the `onStart` hook to ensure service availability in load more calls. This is required since the IBI sites utilize content-to-content scroll.