### PR TITLE
GAM lazy loading

### DIFF
--- a/packages/informa-gam/package.json
+++ b/packages/informa-gam/package.json
@@ -14,7 +14,7 @@
     "@base-cms/inflector": "^1.0.0",
     "@base-cms/marko-core": "^1.26.2",
     "@base-cms/marko-web": "^1.29.10",
-    "@base-cms/marko-web-gam": "^1.25.10",
+    "@base-cms/marko-web-gam": "^1.30.0",
     "@base-cms/object-path": "^1.25.0",
     "@base-cms/utils": "^1.25.0",
     "@base-cms/web-cli": "^1.29.10",

--- a/packages/lazarus-shared/components/document.marko
+++ b/packages/lazarus-shared/components/document.marko
@@ -22,7 +22,9 @@ $ const wrapperStyle = canLoadPrestitial(page) ? "opacity: 0;" : null;
       include-path=false
       include-host=false
       include-env=false
-    />
+    >
+      <@lazy-load ...site.getAsObject("gam.lazyLoad") />
+    </marko-web-gam-enable>
   </@head>
   <@body-wrapper enabled=true attrs={ id: "body-wrapper", class: "full-flex-column", style: wrapperStyle } />
   <@above-wrapper>

--- a/packages/lazarus-shared/package.json
+++ b/packages/lazarus-shared/package.json
@@ -14,7 +14,7 @@
     "@base-cms/image": "^1.6.3",
     "@base-cms/marko-core": "^1.26.2",
     "@base-cms/marko-web": "^1.29.10",
-    "@base-cms/marko-web-gam": "^1.25.10",
+    "@base-cms/marko-web-gam": "^1.30.0",
     "@base-cms/marko-web-gcse": "^1.25.0",
     "@base-cms/marko-web-gtm": "^1.25.0",
     "@base-cms/marko-web-icons": "^1.29.6",

--- a/sites/electronicdesign.com/config/site.js
+++ b/sites/electronicdesign.com/config/site.js
@@ -37,7 +37,16 @@ module.exports = {
     { provider: 'twitter', href: 'https://twitter.com/ElectronicDesgn', target: '_blank' },
     { provider: 'linkedin', href: 'https://www.linkedin.com/groups/4210549/profile', target: '_blank' },
   ],
-  gam: { accountId: process.env.GAM_ACCCOUNT_ID || '3834', basePath: 'elecdes.home' },
+  gam: {
+    accountId: process.env.GAM_ACCCOUNT_ID || '21687441225',
+    basePath: 'elecdes.home',
+    lazyLoad: {
+      enabled: false, // set to true to enable lazy loading
+      fetchMarginPercent: 100, // fetch ad when one viewport away
+      renderMarginPercent: 50, // render ad when half viewport away
+      mobileScaling: 2, // double these on mobile
+    },
+  },
   gtm: {
     containerId: 'GTM-KTXH6VJ',
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -810,10 +810,10 @@
     moment "^2.24.0"
     moment-timezone "^0.5.26"
 
-"@base-cms/marko-web-gam@^1.25.10":
-  version "1.25.10"
-  resolved "https://registry.yarnpkg.com/@base-cms/marko-web-gam/-/marko-web-gam-1.25.10.tgz#f40f44f4d68ebab4c51d8ce0b42efc139bd618ee"
-  integrity sha512-QC2UaGQaozbrElM2mjaNpuEL+3ifKkRStOIv3/jn1yd4jVuUv6m8bbtfDOpNxEF0+66e6aFWVCnVOlqPwDjfxQ==
+"@base-cms/marko-web-gam@^1.30.0":
+  version "1.30.0"
+  resolved "https://registry.yarnpkg.com/@base-cms/marko-web-gam/-/marko-web-gam-1.30.0.tgz#c949b6cf651d26e93d71d8bacee4821c6a4af660"
+  integrity sha512-0GKAE0NMs9xmzkH4ejxgRZyEmNhhn9cHOXNrsEqJImE2EGakMvsM8cgufgzdawpvh7tmVZKRPhjPaX5RrGnssQ==
   dependencies:
     "@base-cms/object-path" "^1.25.0"
     "@base-cms/utils" "^1.25.0"


### PR DESCRIPTION
Add support for lazy loading of ads. This is disabled by default and can be enabled/configured within each site config. An example configuration (though disabled) was added to Electronic Design.

See `sites/electronicdesign.com/config/site.js` for a configuration example.