### PR TITLE
Update Resources menu items

### DIFF
--- a/sites/mwrf.com/config/navigation.js
+++ b/sites/mwrf.com/config/navigation.js
@@ -19,6 +19,7 @@ module.exports = {
   menu: [
     {
       items: [
+        { href: '/page/resources', label: 'MWRF Resources' },
         { href: '/markets/defense', label: 'Defense' },
         { href: '/technologies/test-measurement', label: 'Test & Measurement' },
         { href: '/technologies/components', label: 'Components' },
@@ -26,8 +27,6 @@ module.exports = {
         { href: '/technologies/systems', label: 'Systems' },
         { href: '/materials', label: 'Materials' },
         { href: '/technologies/software', label: 'Software' },
-        { href: '/page/resources', label: 'Resources' },
-        { href: '/page/microwaves-rf-experts', label: 'Experts' },
         { href: '/covid-19', label: 'COVID-19' },
       ],
     },


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/173562845

- Removed the "Experts" link in the hamburger nav.
- Renamed the Resources hamburger menu item "MWRF Resources" and moved it to the top of the menu

Current:
![Screen Shot 2020-07-01 at 12 19 17 PM](https://user-images.githubusercontent.com/6343242/86267697-1da38b80-bb95-11ea-9497-27cba611adca.png)

New:
![Screen Shot 2020-07-01 at 12 16 24 PM](https://user-images.githubusercontent.com/6343242/86267712-24ca9980-bb95-11ea-9803-cdc4ab131584.png)

