### PR TITLE
Port EBM directory layout to Informa sites

### DIFF
--- a/packages/lazarus-shared/browser/auto-scroll.vue
+++ b/packages/lazarus-shared/browser/auto-scroll.vue
@@ -1,0 +1,41 @@
+<template>
+  <div />
+</template>
+
+<script>
+export default {
+  props: {
+    containerTarget: {
+      type: String,
+      required: true,
+    },
+    elementTarget: {
+      type: String,
+      required: true,
+    },
+    offset: {
+      type: Number,
+      default: 0,
+    },
+  },
+  mounted() {
+    if (document.readyState === 'loading') {
+      window.addEventListener('DOMContentLoaded', () => {
+        this.autoScroll();
+      });
+    } else {
+      this.autoScroll();
+    }
+  },
+  methods: {
+    autoScroll() {
+      const container = document.querySelector(this.containerTarget);
+      const element = document.querySelector(this.elementTarget);
+      if (container && element) {
+        const offset = element.getBoundingClientRect().top - container.getBoundingClientRect().top;
+        container.scrollTop = offset + this.offset;
+      }
+    },
+  },
+};
+</script>

--- a/packages/lazarus-shared/browser/directory-facets/list.vue
+++ b/packages/lazarus-shared/browser/directory-facets/list.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="directory-facets__list">
     <auto-scroll
-      v-if="loadAutoScroll"
       container-target=".directory-facets__list"
       element-target=".directory-facet--active"
     />
@@ -64,7 +63,6 @@ export default {
   data: () => ({
     isLoading: false,
     hasLoaded: false,
-    loadAutoScroll: false,
     error: null,
     sections: [],
   }),
@@ -100,7 +98,6 @@ export default {
           this.error = e;
         } finally {
           this.isLoading = false;
-          this.loadAutoScroll = true;
         }
       }
     },

--- a/packages/lazarus-shared/browser/directory-facets/list.vue
+++ b/packages/lazarus-shared/browser/directory-facets/list.vue
@@ -1,5 +1,10 @@
 <template>
   <div class="directory-facets__list">
+    <auto-scroll
+      v-if="loadAutoScroll"
+      container-target=".directory-facets__list"
+      element-target=".directory-facet--active"
+    />
     <loading-spinner v-if="isLoading" />
     <p v-else-if="error">
       Error: {{ error.message }}
@@ -25,6 +30,7 @@
 </template>
 
 <script>
+import AutoScroll from '../auto-scroll.vue';
 import DirectoryFacet from './facet.vue';
 import LoadingSpinner from './loading-spinner.vue';
 import directorySectionsQuery from './graphql/directory-sections';
@@ -33,6 +39,7 @@ import getEdgeNodes from './utils/get-edge-nodes';
 export default {
   name: 'DirectoryFacetsList',
   components: {
+    AutoScroll,
     DirectoryFacet,
     LoadingSpinner,
   },
@@ -57,6 +64,7 @@ export default {
   data: () => ({
     isLoading: false,
     hasLoaded: false,
+    loadAutoScroll: false,
     error: null,
     sections: [],
   }),
@@ -92,6 +100,7 @@ export default {
           this.error = e;
         } finally {
           this.isLoading = false;
+          this.loadAutoScroll = true;
         }
       }
     },

--- a/packages/lazarus-shared/browser/index.js
+++ b/packages/lazarus-shared/browser/index.js
@@ -8,6 +8,7 @@ import SocialSharing from '@base-cms/marko-web-social-sharing/browser';
 import Leaders from '@endeavor-business-media/package-leaders/browser';
 import Inquiry from '@base-cms/marko-web-inquiry/browser';
 import IncrementAdPos from './increment-ad-pos.vue';
+import AutoScroll from './auto-scroll.vue';
 import LoadEloquaIframes from './load-eloqua-iframes.vue';
 
 const GallerySlideshow = () => import(/* webpackChunkName: "lazarus-shared-gallery-slideshow" */ './gallery-slideshow/index.vue');
@@ -25,6 +26,7 @@ export default (Browser) => {
   Inquiry(Browser);
 
   const { EventBus } = Browser;
+  Browser.registerComponent('LazarusAutoScroll', AutoScroll);
   Browser.register('LazarusSharedIncrementAdPos', IncrementAdPos, {
     provide: { EventBus },
   });

--- a/packages/lazarus-shared/scss/_directory-facets.scss
+++ b/packages/lazarus-shared/scss/_directory-facets.scss
@@ -7,7 +7,9 @@
   }
 
   &__list {
+    max-height: 400px;
     margin-bottom: 5px;
+    overflow: scroll;
     #{ $self } {
       &__list {
         padding-left: 21px;

--- a/packages/lazarus-shared/templates/website-section/directory.marko
+++ b/packages/lazarus-shared/templates/website-section/directory.marko
@@ -49,11 +49,18 @@ $ const rootAlias = aliasParts.shift();
           <div class="directory-grid">
             <div class="directory-grid__left-col">
               <lazarus-shared-directory-facets root-alias=rootAlias active-alias=alias />
+              <informa-gam-adunit
+              location="taxonomy"
+              position="left_rail_rect"
+              modifiers=["max-width-300"]
+            >
+              <@context section-id=section.id />
+            </informa-gam-adunit>
             </div>
             <div class="directory-grid__right-col">
               <marko-web-query|{ nodes }|
                 name="website-scheduled-content"
-                params={ sectionId: id, limit: 12, queryFragment }
+                params={ optionName:"Featured", limit:3, includeContentTypes:["Company"], sectionId: id, queryFragment }
               >
                 <lazarus-shared-content-list-flow
                   nodes=nodes
@@ -62,41 +69,58 @@ $ const rootAlias = aliasParts.shift();
                   inner-justified=false
                   modifiers=["feed"]
                 >
+                  <@header>Featured Companies</@header>
                   <@node with-dates=false>
                     <@image width=120 />
                   </@node>
                 </lazarus-shared-content-list-flow>
               </marko-web-query>
-
-              <marko-web-load-more
-                append-to=".directory-grid__right-col"
-                expand=500
-                component-name="lazarus-shared-content-load-more-flow"
-                component-input={
-                  node: { image: { width: 120 }, withDates: false },
-                  adunit: {
-                    location: "taxonomy",
-                    position: "infinitescroll",
-                    context: { sectionId: section.id },
-                  },
-                }
-                fragment-name="content-list"
-                query-name="website-scheduled-content"
-                query-params={ sectionId: id, limit: 12, skip: 12 }
-                page-input={ for: "website-section", id }
-              />
+              <marko-web-query|{ nodes }|
+                name="website-scheduled-content"
+                params={ limit:7, includeContentTypes:["Company"], sectionId: id, queryFragment }
+              >
+                <lazarus-shared-content-list-flow
+                  nodes=nodes
+                  flush-x=true
+                  flush-y=true
+                  inner-justified=false
+                  modifiers=["feed"]
+                >
+                  <@header>Latest Companies</@header>
+                  <@node with-dates=false>
+                    <@image width=120 />
+                  </@node>
+                </lazarus-shared-content-list-flow>
+              </marko-web-query>
             </div>
+          </div>
+          <div>
+
           </div>
         </@section>
       </marko-web-page-wrapper>
     </marko-web-resolve-page>
   </@page>
-  <@below-container>
-    <informa-gam-adunit
-      location="taxonomy"
-      position="hidden"
-    >
-      <@context section-id=id />
-    </informa-gam-adunit>
-  </@below-container>
+  <@below-page>
+    <marko-web-resolve-page|{ data: section, pageInfo }| node=pageNode>
+      $ const { id } = section;
+
+      <marko-web-load-more
+        component-name="lazarus-shared-content-load-more-flow"
+        component-input={
+          node: { image: { width: 120 }, withDates: false },
+          adunit: {
+            location: "taxonomy",
+            position: "infinitescroll",
+            context: { sectionId: id },
+          },
+        }
+        max-pages=3
+        fragment-name="content-list"
+        query-name="website-scheduled-content"
+        query-params={ includeContentTypes: ["Company"], sectionId: id, limit: 18, skip: 7 }
+        page-input={ for: "website-section", id, modifiers: ["directory"] }
+      />
+    </marko-web-resolve-page>
+  </@below-page>
 </marko-web-website-section-page-layout>

--- a/packages/lazarus-shared/templates/website-section/directory.marko
+++ b/packages/lazarus-shared/templates/website-section/directory.marko
@@ -115,7 +115,6 @@ $ const rootAlias = aliasParts.shift();
             context: { sectionId: id },
           },
         }
-        max-pages=3
         fragment-name="content-list"
         query-name="website-scheduled-content"
         query-params={ includeContentTypes: ["Company"], sectionId: id, limit: 18, skip: 7 }

--- a/packages/lazarus-shared/templates/website-section/directory.marko
+++ b/packages/lazarus-shared/templates/website-section/directory.marko
@@ -60,7 +60,7 @@ $ const rootAlias = aliasParts.shift();
             <div class="directory-grid__right-col">
               <marko-web-query|{ nodes }|
                 name="website-scheduled-content"
-                params={ optionName:"Featured", limit:3, includeContentTypes:["Company"], sectionId: id, queryFragment }
+                params={ optionName:"Pinned", limit:3, includeContentTypes:["Company"], sectionId: id, queryFragment }
               >
                 <lazarus-shared-content-list-flow
                   nodes=nodes

--- a/packages/lazarus-shared/theme.scss
+++ b/packages/lazarus-shared/theme.scss
@@ -362,24 +362,49 @@ $theme-content-page-node-full-width: 780px !default;
   }
 }
 
+.page {
+  &--directory {
+    background: transparent;
+
+    .page-grid {
+
+      &__col {
+
+        &--full {
+          padding-right: 0;
+          padding-left: 0;
+
+          & .node-list {
+            padding-right: $grid-gutter-width;
+            padding-left: $grid-gutter-width;
+          }
+
+        }
+
+      }
+
+    }
+
+  }
+}
+
 .directory-grid {
   @include make-row();
 
-  &__left-col {
+  &__left-col,
+  &__right-col {
     @include make-col-ready();
     padding-top: $grid-gutter-width;
     padding-bottom: $grid-gutter-width;
+  }
 
+  &__left-col {
     @include media-breakpoint-up(lg) {
       @include make-col(4);
-      position: sticky;
-      overflow: scroll;
-      @each $breakpoint, $width in sort-map-by-values($theme-site-header-breakpoints, desc) {
-        @media (max-width: $width) {
-          top: calc(#{calculate-navbar-height-for($breakpoint)});
-          height: calc(100vh - #{calculate-navbar-height-for($breakpoint)});
-        }
-      }
+    }
+    & .ad-container {
+      margin-top: $grid-gutter-width * 2;
+      margin-bottom: $grid-gutter-width * 2;
     }
   }
 

--- a/packages/lazarus-shared/theme.scss
+++ b/packages/lazarus-shared/theme.scss
@@ -375,8 +375,8 @@ $theme-content-page-node-full-width: 780px !default;
           padding-left: 0;
 
           & .node-list {
-            padding-right: $grid-gutter-width;
-            padding-left: $grid-gutter-width;
+            padding-right: $grid-gutter-width / 2;
+            padding-left: $grid-gutter-width / 2;
           }
 
         }


### PR DESCRIPTION
[**DEV-22**](https://southcomm.atlassian.net/browse/DEV-22)

- update left col to have scrollable, non-sticky, categories followed by a 300x250 ad
 - update right col to have ability for featured companies(limit of 3) and then a list of latest companies(7)
 - after main portion of page it will scrollin to more companies full with
 — every load more page will have an 970/728 followed by 18 companies.

### Directory Landing Page
![informaDirectory](https://user-images.githubusercontent.com/3845869/90031920-6c0f7400-dc83-11ea-9e05-ae06346a7066.png)


### Directory Category Landing Page
![informaDirectoryCategory](https://user-images.githubusercontent.com/3845869/90031943-70d42800-dc83-11ea-9fe7-92f8fa176db4.png)


### Company Landing Page
![informCompanyLandingPage](https://user-images.githubusercontent.com/3845869/90028266-146f0980-dc7f-11ea-9a5b-a78eb5a67bd0.png)


