### PR TITLE
Add css to account for empty recommended block

### DIFF
--- a/packages/lazarus-shared/components/blocks/home-page-hero-with-recommended.marko
+++ b/packages/lazarus-shared/components/blocks/home-page-hero-with-recommended.marko
@@ -3,8 +3,8 @@ import queryFragment from "../../graphql/fragments/content-list";
 $ const id = input.sectionId;
 
 <div class="col-12 ml-0 mr-0">
-  <div class="row">
-    <div class="col-8 mr-0">
+  <div class="row home-recommended d-flex">
+    <div class="col-md-8 flex-grow-1 mr-0">
       <marko-web-query|{ nodes }|
         name="website-optioned-content"
         params={ sectionId: id, optionName: "Pinned", limit: 1, requiresImage: true, queryFragment }
@@ -20,7 +20,7 @@ $ const id = input.sectionId;
         </default-theme-hero-flow>
       </marko-web-query>
     </div>
-    <div class="col-4 ml-0">
+    <div class="col-md-4 flex-shrink-1 ml-0">
       <marko-web-query|{ nodes }|
         name="website-scheduled-content"
         params={ sectionId: id, optionName: "Recommended", limit: 2, requiresImage: true, queryFragment }

--- a/packages/lazarus-shared/templates/index.marko
+++ b/packages/lazarus-shared/templates/index.marko
@@ -2,7 +2,6 @@ import queryFragment from "../graphql/fragments/content-list";
 
 $ const { GAM, site } = out.global;
 $ const { id, alias, name, pageNode } = data;
-$ const homePageRecommended = site.get("homePageRecommended.enabled");
 
 <marko-web-website-section-page-layout id=id alias=alias name=name>
   <@head>

--- a/packages/lazarus-shared/theme.scss
+++ b/packages/lazarus-shared/theme.scss
@@ -101,6 +101,16 @@ $theme-content-page-node-full-width: 780px !default;
   height: 100%;
 }
 
+.home-recommended {
+  .col-md-8.flex-grow-1 {
+    max-width: initial;
+  }
+
+  .col-md-4.flex-shrink-1:empty {
+    display: none;
+  }
+}
+
 .ad-container {
   @include gutter-padding-x-modifier();
   @include gutter-padding-y-modifier();
@@ -386,6 +396,12 @@ $theme-content-page-node-full-width: 780px !default;
 
     }
 
+  }
+
+  &--company-load-more {
+    padding-top: $marko-web-node-list-padding;
+    padding-right: $marko-web-node-list-padding;
+    padding-left: $marko-web-node-list-padding;
   }
 }
 
@@ -703,14 +719,6 @@ $theme-content-page-node-full-width: 780px !default;
 .embed-container-eloqua {
   padding-bottom: $theme-content-paragraph-margin-bottom;
   clear: both;
-}
-
-.page {
-  &--company-load-more {
-    padding-top: $marko-web-node-list-padding;
-    padding-right: $marko-web-node-list-padding;
-    padding-left: $marko-web-node-list-padding;
-  }
 }
 
 .page-contents {


### PR DESCRIPTION
add css to use flex grow when right col-md-4 is empty on the homepage

![Screen Shot 2020-09-15 at 2 14 12 PM](https://user-images.githubusercontent.com/3845869/93254371-dc675480-f75d-11ea-9641-bc2d8e18b21a.png)
![Screen Shot 2020-09-15 at 2 14 20 PM](https://user-images.githubusercontent.com/3845869/93254388-e2f5cc00-f75d-11ea-9e04-b6292a7ad6d9.png)
![Screen Shot 2020-09-15 at 2 14 32 PM](https://user-images.githubusercontent.com/3845869/93254403-e8531680-f75d-11ea-8689-500fe8d548de.png)
![Screen Shot 2020-09-15 at 2 14 46 PM](https://user-images.githubusercontent.com/3845869/93254411-ebe69d80-f75d-11ea-8f13-03e39e2e1ad0.png)
