### PR TITLE
Corrected load-more config for magazine issue page

### DIFF
--- a/packages/lazarus-shared/templates/magazine/issue.marko
+++ b/packages/lazarus-shared/templates/magazine/issue.marko
@@ -57,8 +57,8 @@ $ const { id, pageNode } = data;
     <marko-web-resolve-page|{ data: issue }| node=pageNode>
       <marko-web-load-more
         header=`More Content from ${issue.name}`
-        component-name="shared-content-card-deck-flow"
-        fragment-name="shared-content-list"
+        component-name="lazarus-shared-content-card-deck-flow"
+        fragment-name="content-list"
         query-name="magazine-scheduled-content"
         query-params={ issueId: id, limit: 10, skip: 5 }
         page-input={ for: "magazine-issue", id }


### PR DESCRIPTION
https://southcomm.atlassian.net/browse/DEV-144

On the live site, the load more content was not displaying.

New:
![screenshot-0 0 0 0_5734-2020 09 22-08_58_29](https://user-images.githubusercontent.com/6343242/93887098-42029600-fcb4-11ea-8a52-20dbc59cd608.png)
