### PR TITLE
Lazarus Theme Updates

### DIFF
--- a/packages/lazarus-shared/theme.scss
+++ b/packages/lazarus-shared/theme.scss
@@ -439,12 +439,6 @@ $theme-content-page-node-full-width: 780px !default;
   &__left-col {
     padding-top: $grid-gutter-width;
     padding-bottom: $grid-gutter-width;
-    @each $breakpoint, $width in sort-map-by-values($theme-site-header-breakpoints, desc) {
-      @media (max-width: $width) {
-        top: calc(#{calculate-navbar-height-for($breakpoint)});
-        height: calc(100vh - #{calculate-navbar-height-for($breakpoint)});
-      }
-    }
   }
 
   &__right-col {

--- a/packages/lazarus-shared/theme.scss
+++ b/packages/lazarus-shared/theme.scss
@@ -122,9 +122,11 @@ $theme-content-page-node-full-width: 780px !default;
   }
 
   &--left-rail-sticky {
-    position: sticky;
-    top: -$grid-gutter-width;
-    z-index: 1;
+    @media (min-width: 1068px) {
+      position: sticky;
+      top: -$grid-gutter-width;
+      z-index: 1;
+    }
   }
 
   &--text-left {


### PR DESCRIPTION
This PR needs to be released in conjunction with the /base-cms PR: https://github.com/base-cms/base-cms/pull/480

https://southcomm.atlassian.net/browse/DEV-157

Allow the left column to display on mobile sizes without the sticky elements.
Left column displays below the right column on mobile sizes.

Note: The header and footer display issues are pre-existing concerns with Electronic Design.

New Mobile:
<img width="414" alt="Screen Shot 2020-09-24 at 9 46 28 PM" src="https://user-images.githubusercontent.com/6343242/94217969-52cc2b00-feb1-11ea-9a37-857433032009.png">


New Tablet:
<img width="842" alt="Screen Shot 2020-09-24 at 9 53 45 PM" src="https://user-images.githubusercontent.com/6343242/94217956-4cd64a00-feb1-11ea-9caa-a7fb61274792.png">


