### PR TITLE
Correct mobile layout of footer

### DIFF
--- a/packages/lazarus-shared/theme.scss
+++ b/packages/lazarus-shared/theme.scss
@@ -834,3 +834,12 @@ $theme-content-page-node-full-width: 780px !default;
     height: 100%;
   }
 }
+
+.site-footer {
+  &__items {
+    flex-direction: column;
+    @include media-breakpoint-up(lg) {
+      flex-direction: row;
+    }
+  }
+}


### PR DESCRIPTION
Footers were exceeding screen limits on mobile (header fix coming in separate PR)

Current:
<img width="366" alt="ed-current-footer" src="https://user-images.githubusercontent.com/6343242/94301146-198ace00-ff38-11ea-86df-56d4c8bd19b5.png">

New:
<img width="387" alt="Screen Shot 2020-09-25 at 2 02 00 PM" src="https://user-images.githubusercontent.com/6343242/94301158-1ee81880-ff38-11ea-9684-1cd6acc1b2a4.png">
<img width="792" alt="Screen Shot 2020-09-25 at 2 01 45 PM" src="https://user-images.githubusercontent.com/6343242/94301159-1ee81880-ff38-11ea-886b-9b050d50a2ad.png">
