### PR TITLE
Corrected layout on homePageSections A/B for content-hero-flow

### DIFF
--- a/packages/lazarus-shared/templates/index.marko
+++ b/packages/lazarus-shared/templates/index.marko
@@ -29,59 +29,63 @@ $ const { id, alias, name, pageNode } = data;
                   </lazarus-skin-page-grid-col>
 
                 $ const [sectionA, sectionB, sectionC] = site.getAsArray("homePageSections");
-                <if(sectionA)>
-                  <div class="col-md-6 mb-block">
+                <if(sectionA || sectionB)>
+                  <div class="row">
+                    <if(sectionA)>
+                      <div class="col-md-6 mb-block">
 
-                    <marko-web-query|{ nodes }|
-                      name="website-scheduled-content"
-                      params={ sectionAlias: sectionA.alias, limit: 3, requiresImage: true, queryFragment }
-                    >
-                      <lazarus-shared-content-hero-flow nodes=nodes>
-                        <@header>
-                          <marko-web-link href=`/${sectionA.alias}`>
-                            ${sectionA.name}
-                          </marko-web-link>
-                        </@header>
-                        <@card
-                          with-teaser=false
-                          with-section=false
-                          modifiers=["dark", "increased-padding"]
-                        />
-                        <@list>
-                          <@node with-teaser=false with-section=false />
-                          <@adunit location="homepage" position="native_category_1" modifiers=["no-shadow", "text-left"] />
-                        </@list>
-                      </lazarus-shared-content-hero-flow>
-                    </marko-web-query>
+                        <marko-web-query|{ nodes }|
+                          name="website-scheduled-content"
+                          params={ sectionAlias: sectionA.alias, limit: 3, requiresImage: true, queryFragment }
+                        >
+                          <lazarus-shared-content-hero-flow nodes=nodes>
+                            <@header>
+                              <marko-web-link href=`/${sectionA.alias}`>
+                                ${sectionA.name}
+                              </marko-web-link>
+                            </@header>
+                            <@card
+                              with-teaser=false
+                              with-section=false
+                              modifiers=["dark", "increased-padding"]
+                            />
+                            <@list>
+                              <@node with-teaser=false with-section=false />
+                              <@adunit location="homepage" position="native_category_1" modifiers=["no-shadow", "text-left"] />
+                            </@list>
+                          </lazarus-shared-content-hero-flow>
+                        </marko-web-query>
 
-                  </div>
-                </if>
+                      </div>
+                    </if>
 
-                <if(sectionB)>
-                  <div class="col-md-6 mb-block">
+                    <if(sectionB)>
+                      <div class="col-md-6 mb-block">
 
-                    <marko-web-query|{ nodes }|
-                      name="website-scheduled-content"
-                      params={ sectionAlias: sectionB.alias, limit: 3, requiresImage: true, queryFragment }
-                    >
-                      <lazarus-shared-content-hero-flow nodes=nodes>
-                        <@header>
-                          <marko-web-link href=`/${sectionB.alias}`>
-                            ${sectionB.name}
-                          </marko-web-link>
-                        </@header>
-                        <@card
-                          with-teaser=false
-                          with-section=false
-                          modifiers=["dark", "increased-padding"]
-                        />
-                        <@list>
-                          <@node with-teaser=false with-section=false />
-                          <@adunit location="homepage" position="native_category_2" modifiers=["no-shadow", "text-left"] />
-                        </@list>
-                      </lazarus-shared-content-hero-flow>
-                    </marko-web-query>
+                        <marko-web-query|{ nodes }|
+                          name="website-scheduled-content"
+                          params={ sectionAlias: sectionB.alias, limit: 3, requiresImage: true, queryFragment }
+                        >
+                          <lazarus-shared-content-hero-flow nodes=nodes>
+                            <@header>
+                              <marko-web-link href=`/${sectionB.alias}`>
+                                ${sectionB.name}
+                              </marko-web-link>
+                            </@header>
+                            <@card
+                              with-teaser=false
+                              with-section=false
+                              modifiers=["dark", "increased-padding"]
+                            />
+                            <@list>
+                              <@node with-teaser=false with-section=false />
+                              <@adunit location="homepage" position="native_category_2" modifiers=["no-shadow", "text-left"] />
+                            </@list>
+                          </lazarus-shared-content-hero-flow>
+                        </marko-web-query>
 
+                      </div>
+                    </if>
                   </div>
                 </if>
 


### PR DESCRIPTION
Added a row around the col blocks in the homepage sections so that they would wrap appropriately on desktop.

Current:
<img width="892" alt="Screen Shot 2020-10-05 at 9 42 44 AM" src="https://user-images.githubusercontent.com/6343242/95088839-72552600-06f1-11eb-825c-491fb5343495.png">

New:
<img width="882" alt="Screen Shot 2020-10-05 at 9 59 37 AM" src="https://user-images.githubusercontent.com/6343242/95088884-7f721500-06f1-11eb-844c-c41417a8e738.png">
