### PR TITLE
add passthrough of querystring from website url to eloqua iframe

### DIFF
--- a/packages/lazarus-shared/browser/load-eloqua-iframes.vue
+++ b/packages/lazarus-shared/browser/load-eloqua-iframes.vue
@@ -15,7 +15,7 @@ export default {
     const elements = document.querySelectorAll(this.selector);
     Array.prototype.forEach.call(elements, (element) => {
       const qs = window.location.search.substring(1);
-      const src = `${element.getAttribute('data-src')}?${qs}`;
+      const src = element.getAttribute('data-src').includes('?') ? `${element.getAttribute('data-src')}&${qs}` : `${element.getAttribute('data-src')}?${qs}`;
       const hasProcessed = element.getAttribute('data-has-processed');
       if (!hasProcessed && src) {
         const iframe = document.createElement('iframe');

--- a/packages/lazarus-shared/browser/load-eloqua-iframes.vue
+++ b/packages/lazarus-shared/browser/load-eloqua-iframes.vue
@@ -14,7 +14,8 @@ export default {
   created() {
     const elements = document.querySelectorAll(this.selector);
     Array.prototype.forEach.call(elements, (element) => {
-      const src = element.getAttribute('data-src');
+      const qs = window.location.search.substring(1);
+      const src = `${element.getAttribute('data-src')}?${qs}`;
       const hasProcessed = element.getAttribute('data-has-processed');
       if (!hasProcessed && src) {
         const iframe = document.createElement('iframe');


### PR DESCRIPTION
Sales started adding tracking codes in mailed links to certain Whitepapers which are gated by eloqua forms.  Since those are iframe embeds, the qs needs to be maintained to get the value into the form itself.