### PR TITLE
Remove `native_article_4` gam position from section pages

### DIFF
--- a/packages/lazarus-shared/components/page-wrappers/website-section/default.marko
+++ b/packages/lazarus-shared/components/page-wrappers/website-section/default.marko
@@ -88,14 +88,14 @@ $ const children = resolved.getEdgeNodesFor("children");
           </lazarus-skin-page-grid-col>
 
           <!-- @todo Find a site that implements this position -->
-          <informa-gam-adunit
+          <!-- <informa-gam-adunit
             location="taxonomy"
             position="native_article_4"
             class="mb-block"
             modifiers=["no-shadow", "text-left"]
           >
             <@context section-id=section.id />
-          </informa-gam-adunit>
+          </informa-gam-adunit> -->
 
           <marko-web-query|{ nodes }|
             name="website-scheduled-content"


### PR DESCRIPTION
The ad team is continuously accidentally targeting this position in GAM, causing confusion among the groups.  I dug around GAM and it doesn’t look like anyone’s actually using this position (correctly) so it’s being commented out until/if they want it.

### Block removed (otherwise would display under the "Sign up for Industry Week eNewsletters" bit)

![image](https://user-images.githubusercontent.com/12496550/95990457-2ab95300-0df1-11eb-909d-f69e03580f53.png)

-----


### Currently on prod:


![image](https://user-images.githubusercontent.com/12496550/95990501-386ed880-0df1-11eb-9ec7-19137e5403fe.png)


