### PR TITLE
Exclude banner ads on ED promotion content type

### DIFF
--- a/packages/lazarus-shared/templates/content/index.marko
+++ b/packages/lazarus-shared/templates/content/index.marko
@@ -11,12 +11,14 @@ $ const { id, type, pageNode } = data;
     </marko-web-gtm-content-context>
   </@head>
   <@above-container>
-    <informa-gam-adunit
-      location="article"
-      position="hidden"
-    >
-      <@context content-id=id />
-    </informa-gam-adunit>
+    <if (type !== "promotion" && site.name !== "electronicdesign.com")>
+      <informa-gam-adunit
+        location="article"
+        position="hidden"
+      >
+        <@context content-id=id />
+      </informa-gam-adunit>
+    </if>
   </@above-container>
   <@page>
 
@@ -24,13 +26,15 @@ $ const { id, type, pageNode } = data;
       $ const section = resolved.getAsObject("primarySection");
       $ const labels = resolved.getAsArray("primarySection.labels");
 
-      <informa-gam-adunit
-        location=adLocation(type)
-        position="top_banner"
-        modifiers=["top-of-page"]
-      >
-        <@context content-id=content.id />
-      </informa-gam-adunit>
+      <if (type !== "promotion" && site.name !== "electronicdesign.com")>
+        <informa-gam-adunit
+          location=adLocation(type)
+          position="top_banner"
+          modifiers=["top-of-page"]
+        >
+          <@context content-id=content.id />
+        </informa-gam-adunit>
+      </if>
 
       <if(labels.includes("Program"))>
         <lazarus-shared-content-program-page-wrapper content=content section=section />


### PR DESCRIPTION
https://southcomm.atlassian.net/browse/DEV-244

Exclude banner ads on Electronic Design's promotion content type.

New:
<img width="1238" alt="Screen Shot 2020-10-14 at 9 42 55 AM" src="https://user-images.githubusercontent.com/6343242/95999271-b89e3980-0e03-11eb-859f-3ece81531c00.png">

Current:
<img width="1306" alt="Screen Shot 2020-10-14 at 9 43 10 AM" src="https://user-images.githubusercontent.com/6343242/95999293-be941a80-0e03-11eb-9fcf-85ecc7e9d0fd.png">
