### PR TITLE
Homepage block rearrangements 

### DIFF
--- a/sites/electronicdesign.com/config/site.js
+++ b/sites/electronicdesign.com/config/site.js
@@ -15,8 +15,8 @@ module.exports = {
   },
   homePageSections: [
     { alias: 'resources/technology-advancements', name: 'Technology Advancements' },
-    { alias: 'resources/products-and-solutions', name: 'Products and Solutions' },
     { alias: 'resources/industry-insights', name: 'Industry Insights' },
+    { alias: 'resources/products-and-solutions', name: 'Products and Solutions' },
   ],
   logos: {
     navbar: {

--- a/sites/mwrf.com/config/site.js
+++ b/sites/mwrf.com/config/site.js
@@ -11,9 +11,9 @@ module.exports = {
     comments: { enabled: true },
   },
   homePageSections: [
-    { alias: 'markets/defense', name: 'Defense' },
-    { alias: 'technologies/components', name: 'Components' },
-    { alias: 'technologies/systems', name: 'Systems' },
+    { alias: 'resources/technology-advancements', name: 'Technology Advancements' },
+    { alias: 'resources/industry-insights', name: 'Industry Insights' },
+    { alias: 'resources/products-and-solutions', name: 'Products and Solutions' },
   ],
   logos: {
     navbar: {


### PR DESCRIPTION
https://southcomm.atlassian.net/browse/DEV-286

### Electronic Design:

- Swap the "Products and Solutions" & "Industry Insights" content blocks around

<img width="1238" alt="Screen Shot 2020-10-14 at 11 44 35 AM" src="https://user-images.githubusercontent.com/12496550/96019988-fd7d9c80-0e12-11eb-9e9a-ba7d38f0dba9.png">


### MWRF:

- Replace the "Defense" content block with "Technology Advancements" (https://www.mwrf.com/resources/technology-advancements)

- Replace the  "Components" content block with "Industry Insights" (https://www.mwrf.com/resources/industry-insights)

- Replace the "Systems" content block with"Products and Solutions" (https://www.mwrf.com/resources/products-and-solutions)

<img width="1079" alt="Screen Shot 2020-10-14 at 11 51 34 AM" src="https://user-images.githubusercontent.com/12496550/96020577-dd9aa880-0e13-11eb-98ac-7b33c94f720a.png">
