### PR TITLE
Various navigation updates

### DIFF
--- a/sites/asumag.com/config/navigation.js
+++ b/sites/asumag.com/config/navigation.js
@@ -36,7 +36,7 @@ module.exports = {
       items: [
         { href: '/page/awards', label: 'Awards & Competitions' },
         { href: '/magazine/5e6b9462a1b8b3c981e0f161', label: 'Digital Back Issues' },
-        { href: 'http://schooldesigns.com', label: 'SchoolDesigns.com', target: '_blank' },
+        { href: 'https://schooldesigns.com', label: 'SchoolDesigns.com', target: '_blank' },
         { href: '/resources', label: 'Resources' },
         { href: '/resources/webinars', label: 'Webinars' },
         { href: '/resources/white-papers', label: 'White Papers' },

--- a/sites/contractingbusiness.com/config/navigation.js
+++ b/sites/contractingbusiness.com/config/navigation.js
@@ -39,7 +39,7 @@ module.exports = {
         { href: '/learning-resources/webinars', label: 'Webinars' },
         { href: '/learning-resources/faqs', label: 'FAQs' },
         { href: '/awards', label: 'Awards' },
-        { href: 'http://contractingbusiness.hotims.com/r5/search.asp?action=search&return_by_category=y', label: 'Free Advertiser Info', target: '_blank' },
+        { href: 'https://contractingbusiness.hotims.com/r5/search.asp?action=search&return_by_category=y', label: 'Free Advertiser Info', target: '_blank' },
         { href: '/downloads', label: 'Monthly Downloads' },
         { href: '/page/contracting-business-industry-experts-and-advisors', label: 'Industry Experts and Advisors' },
         { href: '/page/about-us', label: 'About Us' },

--- a/sites/electricalmarketing.com/config/navigation.js
+++ b/sites/electricalmarketing.com/config/navigation.js
@@ -10,7 +10,6 @@ module.exports = {
     items: [
       { href: '/page/about-us', label: 'About Us' },
       { href: '/page/contact-us', label: 'Contact Us' },
-      { href: 'http://ebmarketing.penton.com/brands/electrical-marketing/', label: 'Advertise', target: '_blank' },
       { href: 'https://endeavor.dragonforms.com/loading.do?omedasite=EBM_DoNotSell', label: 'California Do Not Sell', target: '_blank' },
       { href: 'https://www.endeavorbusinessmedia.com/privacy-policy', label: 'Privacy & Cookie Policy', target: '_blank' },
       { href: 'https://www.endeavorbusinessmedia.com/endeavor-terms', label: 'Terms of Service', target: '_blank' },
@@ -33,7 +32,6 @@ module.exports = {
         { href: '/current-issue', label: 'Digital Edition' },
         { href: '/industry-stats/electrical-price-index', label: 'Electrical Price Index' },
         { href: '/page/about-us', label: 'About Us' },
-        { href: 'http://ebmarketing.penton.com/brands/electrical-marketing/', label: 'Advertise', target: '_blank' },
         { href: dragonForms.getFormUrl('newsletterSubscribe'), label: 'eNewsletter Subscription', target: '_blank' },
         { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },
         { href: 'https://www.endeavorbusinessmedia.com/privacy-policy', label: 'Privacy & Cookie Policy', target: '_blank' },

--- a/sites/electronicdesign.com/config/navigation.js
+++ b/sites/electronicdesign.com/config/navigation.js
@@ -33,7 +33,7 @@ module.exports = {
     {
       modifiers: ['secondary'],
       items: [
-        { href: 'http://sourceesb.com/', label: 'Find Parts', target: '_blank' },
+        { href: 'https://sourceesb.com/', label: 'Find Parts', target: '_blank' },
         { href: '/magazine-digital-archive', label: 'Digital Archive' },
         { href: '/learning-resources/webcasts', label: 'Webinars' },
         { href: '/learning-resources/white-paper', label: 'White Papers' },

--- a/sites/hydraulicspneumatics.com/config/navigation.js
+++ b/sites/hydraulicspneumatics.com/config/navigation.js
@@ -23,15 +23,15 @@ module.exports = {
         { href: '/technologies/hydraulic-valves', label: 'Hydraulic Valves' },
         { href: '/technologies/hydraulic-pumps-motors', label: 'Hydraulic Pumps & Motors' },
         { href: '/technologies/cylinders-actuators', label: 'Cylinders and Actuators' },
-        { href: '/directories', label: 'Directories' },
+        { href: '/hpconnect', label: 'H&P Connect' },
         { href: '/learning-resources', label: 'Resources' },
-        { href: '/page/community/hydraulics-pneumatics-experts', label: 'Experts' },
+        { href: '/magazine/5e6baaf6a1b8b3c9814869e5', label: 'Digital Edition Archives' },
       ],
     },
     {
       modifiers: ['secondary'],
       items: [
-        { href: '/manufacturer-directory', label: 'Manufacturers Directory' },
+        { href: '/hpconnect', label: 'Manufacturers Directory' },
         { href: '/distributor-directory', label: 'Distributors Directory' },
         { href: '/hydraulics-pneumatics-blogs', label: 'Blogs' },
         { href: 'https://directory.newequipment.com/', label: 'Equipment Product Directory' },

--- a/sites/hydraulicspneumatics.com/config/navigation.js
+++ b/sites/hydraulicspneumatics.com/config/navigation.js
@@ -34,7 +34,7 @@ module.exports = {
         { href: '/manufacturer-directory', label: 'Manufacturers Directory' },
         { href: '/distributor-directory', label: 'Distributors Directory' },
         { href: '/hydraulics-pneumatics-blogs', label: 'Blogs' },
-        { href: 'http://directory.newequipment.com/', label: 'Equipment Product Directory' },
+        { href: 'https://directory.newequipment.com/', label: 'Equipment Product Directory' },
         { href: '/learning-resources/basics-design', label: 'Basics of Design' },
         { href: '/learning-resources/design-faqs', label: 'Design FAQs' },
         { href: '/learning-resources/webinar', label: 'Webinars' },

--- a/sites/industryweek.com/config/navigation.js
+++ b/sites/industryweek.com/config/navigation.js
@@ -31,7 +31,7 @@ module.exports = {
     {
       modifiers: ['secondary'],
       items: [
-        { href: 'http://directory.newequipment.com/', label: 'Manufacturing Products' },
+        { href: 'https://directory.newequipment.com/', label: 'Manufacturing Products' },
         { href: '/resources/industryweek-best-plants-awards', label: 'IndustryWeek Best Plants Awards' },
         { href: '/resources/industryweek-50-best-us-manufacturers', label: 'IW US 50 Best' },
         { href: '/resources/industryweek-us-500', label: 'IW US 500' },

--- a/sites/machinedesign.com/config/navigation.js
+++ b/sites/machinedesign.com/config/navigation.js
@@ -33,12 +33,13 @@ module.exports = {
     {
       modifiers: ['secondary'],
       items: [
+        { href: '/magazine/5e6babaaa1b8b3c9814b80f2', label: 'Digital Edition Archives' },
         { href: 'https://www.csiaexchange.com/', label: 'CSIA Exchange', target: '_blank' },
         { href: '/markets', label: 'Markets' },
-        { href: 'http://www.electronicdesign.com/', label: 'Design with Electronics' },
-        { href: 'http://directory.newequipment.com/', label: 'Equipment Product Directory' },
-        { href: 'http://www.industryweek.com/', label: 'The Business of Manufacturing' },
-        { href: 'http://www.hydraulicspneumatics.com/', label: 'Hydraulics & Pneumatics' },
+        { href: 'https://www.electronicdesign.com/', label: 'Electronic Design' },
+        { href: 'https://directory.newequipment.com/', label: 'New Equipment Digest' },
+        { href: 'https://www.industryweek.com/', label: 'Industry Week' },
+        { href: 'https://www.hydraulicspneumatics.com/', label: 'Hydraulics & Pneumatics' },
         { href: 'https://www.mfgtechshow.com/', label: 'Manufacturing & Technology Event', target: '_blank' },
         { href: 'https://www.safetyleadershipconference.com/', label: 'Safety Leadership Conference', target: '_blank' },
         { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },

--- a/sites/newequipment.com/config/navigation.js
+++ b/sites/newequipment.com/config/navigation.js
@@ -23,14 +23,14 @@ module.exports = {
         { href: '/technology-innovations', label: 'Technology Innovations' },
         { href: '/plant-operations', label: 'Plant Operations' },
         { href: '/research-and-development', label: 'Research & Development' },
-        { href: 'http://directory.newequipment.com', label: 'Find Products' },
-        { href: 'http://directory.newequipment.com/top/companies', label: 'Browse Suppliers' },
+        { href: 'https://directory.newequipment.com', label: 'Find Products' },
+        { href: 'https://directory.newequipment.com/top/companies', label: 'Browse Suppliers' },
       ],
     },
     {
       modifiers: ['secondary'],
       items: [
-        { href: 'http://directory.newequipment.com/', label: 'NED Directory' },
+        { href: 'https://directory.newequipment.com/', label: 'NED Directory' },
         { href: 'https://www.mfgtechshow.com/', label: 'Manufacturing & Technology Event', target: '_blank' },
         { href: 'https://www.safetyleadershipconference.com/', label: 'Safety Leadership Conference', target: '_blank' },
         { href: dragonForms.getFormUrl('magazineSignup'), label: 'Magazine Subscription', target: '_blank' },

--- a/sites/sourcetoday.com/config/navigation.js
+++ b/sites/sourcetoday.com/config/navigation.js
@@ -34,8 +34,8 @@ module.exports = {
       items: [
         { href: 'https://sourceesb.com/', label: 'Find Parts' },
         { href: 'https://www.sourcetoday.com/distribution/digital-issue', label: 'Digital Issue' },
-        { href: 'http://www.industryweek.com/supply-chain', label: 'Business of Manufacturing' },
-        { href: 'http://directory.newequipment.com/products/electrical-and-electronics', label: 'Equipment Product Directory' },
+        { href: 'https://www.industryweek.com/supply-chain', label: 'Business of Manufacturing' },
+        { href: 'https://directory.newequipment.com/products/electrical-and-electronics', label: 'Equipment Product Directory' },
         { href: dragonForms.getFormUrl('newsletterSubscribe'), label: 'eNewsletter Subscription', target: '_blank' },
         { href: '/page/about-us', label: 'About Us' },
         { href: '/page/contact-us', label: 'Contact Us' },

--- a/sites/trucker.com/config/navigation.js
+++ b/sites/trucker.com/config/navigation.js
@@ -28,7 +28,7 @@ module.exports = {
         { href: '/galleries', label: 'Galleries' },
         { href: '/american-trucker-magazine', label: 'American Trucker Magazine' },
         { href: '/inquire', label: 'Advertiser Info' },
-        { href: 'http://equipmentsearch.trucker.com/', label: 'Equipment Search' },
+        { href: 'https://equipmentsearch.trucker.com/', label: 'Equipment Search' },
       ],
     },
     {


### PR DESCRIPTION
Did a find in all `sites` for `http:` and updated them to `https:` (I double-checked each URL before updating to make sure they were all actually secure).  Found one that didn't work at all, so I removed it ("Advertise" on electricalmarketing.com).

Also updated some nav links in HPN and MD per https://southcomm.atlassian.net/browse/DEV-298

(Copied from the ticket):
### Hamburger menu changes for HydraulicsPneumatics.com:

• Replace “Directories” with “H&P Connect”, and point it to https://www.hydraulicspneumatics.com/hpconnect

• Replace “Experts” with “Digital Edition Archives” and point it to https://www.hydraulicspneumatics.com/magazine/5e6baaf6a1b8b3c9814869e5

• Lower in the menu, re-point “Manufacturer’s Directory” to https://www.hydraulicspneumatics.com/hpconnect

### Hamburger menu changes for MachineDesign.com:
• Above the CSIA Exchange listing (at the top of the lower part of the menu) add “Digital Edition Archives” and point it at https://www.machinedesign.com/magazine/5e6babaaa1b8b3c9814b80f2

• Change “Design With Electronics” to “Electronic Design”

• Change “Equipment Product Directory” to “New Equipment Digest”

• Change “The Business of Manufacturing” to “Industry Week”