### PR TITLE
Enable Leaders on H&P

### DIFF
--- a/packages/leaders/scss/index-page.scss
+++ b/packages/leaders/scss/index-page.scss
@@ -7,19 +7,18 @@
   }
 
   &__title {
-    margin-bottom: .75rem;
+    margin: .75rem 0;
     font-size: 34px;
   }
 
   &__header {
-    margin-bottom: .75rem;
+    margin: .75rem 0;
   }
 
   &__logo {
     display: flex;
     padding: .75rem;
-    margin-right: .75rem;
-    margin-bottom: .75rem;
+    margin: .75rem .75rem .75rem 0;
     background-color: $leaders-primary-color;
   }
 

--- a/sites/hydraulicspneumatics.com/config/leaders.js
+++ b/sites/hydraulicspneumatics.com/config/leaders.js
@@ -1,0 +1,11 @@
+module.exports = {
+  title: 'Leaders in Hydraulics & Pneumatics',
+  alias: 'hpconnect',
+  calloutValue: 'Welcome to H&P Connect',
+  header: {
+    imgSrc: 'https://img.hydraulicspneumatics.com/files/base/ebm/hydraulicspneumatics/image/static/hp_leaders.png?h=90',
+  },
+  // Remove this (or set to true) to enable integrated components on the home page and content page
+  // This has no effect on the leaders landing page
+  componentsEnabled: false,
+};

--- a/sites/hydraulicspneumatics.com/config/site.js
+++ b/sites/hydraulicspneumatics.com/config/site.js
@@ -1,10 +1,12 @@
 const navigation = require('./navigation');
 const dragonForms = require('./dragon-forms');
+const leaders = require('./leaders');
 
 module.exports = {
   company: 'Endeavor Business Media, LLC',
   navigation,
   dragonForms,
+  leaders,
   identityX: {
     enabled: true,
     appId: '5df0e8dc05aa5681de43fc36',

--- a/sites/hydraulicspneumatics.com/server/styles/index.scss
+++ b/sites/hydraulicspneumatics.com/server/styles/index.scss
@@ -4,3 +4,9 @@ $theme-site-navbar-menu-bg-color: #333e48;
 $theme-lazarus-card-bg-color-dark: rgba(9, 11, 12, .9);
 
 @import "../../node_modules/@endeavor-business-media/lazarus-shared/theme";
+
+.leaders-index-page {
+  &__logo {
+    background-color: #fff;
+  }
+}


### PR DESCRIPTION
Add Leaders to H&P's /hpconnect page: https://www.hydraulicspneumatics.com/hpconnect

Updated logo background color: 
![image](https://user-images.githubusercontent.com/12496550/97459519-dbebdd00-1909-11eb-852b-2d11649a76f4.png)


Also equalized the margin around the header.  Above image is post-change, here's what it looks like on prod (with default background color):
<img width="1135" alt="Screen Shot 2020-10-27 at 8 42 17 AM" src="https://user-images.githubusercontent.com/12496550/97310373-264d5b00-1831-11eb-8f24-6d89f22cc21b.png">

